### PR TITLE
Ckan media integration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ govCMS CKAN provides integration with CKAN (http://ckan.org/). CKAN is a
 powerful data management system that makes data accessible by providing tools to
 streamline publishing, sharing, finding and using data.
 
+Submodules
+----------
+
+govCMS CKAN Display
+- Handles turning the tabular data into charts.
+- Provides ability to download charts as svg/png.
+- Provides visualisation plugins for common formats (eg. Bar, spline, line)
+
+govCMS CKAN Display Examples
+- Provides an examples page for viewing different chart types.
+
+govCMS CKAN Media
+- Provides media internet integration.
+- Provides a CKAN file type and stream wrapper/handler.
+- Visualisation configuration field/widget.
+- Visualisation formatter/renderer.
+
 GovCmsCkanClient Class
 ----------------------
 This client class handles fetching, caching and returning data from a CKAN endpoint.
@@ -28,16 +45,88 @@ $client->get($resource, $query_params);
 This will make a request to the api which will look similar to this:
 http://my.ckan.enpoint.baseurl/api/3/action/package_show?id=1234
 
+Valid responses:
+
+The response object should always contain a `valid` property to indicate if the data
+returned is valid/usable. If FALSE there was either an error in the http request or
+possibly the CKAN request. All failed requests will get added to watchdog.
+
 Examples of resources:
-action/package_show - metadata for a package
-action/dataset - tabular data for a package
+action/package_show - metadata for a resource
+action/datastore_search - records (data) for a resource
 
-Submodules
-----------
+Wrappers/Helpers:
+```
+// Return a resource metadata.
+$meta = govcms_ckan_client_request_meta($resource_id);
 
-govCMS CKAN Display
-- Handles turning the tabular data into charts.
-- Provides ability to download charts as svg/png.
+// Return the records for a resource.
+$records = govcms_ckan_client_request_records($resource_id);
+```
 
-govCMS CKAN Display Examples
-- Provides an examples page for viewing different chat types.
+GovCmsCkanDatasetParser Class
+-----------------------------
+This parser class handles parsing the response records from the client class into table(s).
+
+The parsed output is in a format for handing straight to theme_table either directly or by
+using a renderable array. Data can be represented in multiple ways, and this class provides
+setters to control how the data/table will be presented.
+
+Basic usage of the class:
+```
+// Get a new instance of the class.
+$parser = govcms_ckan_dataset_parser();
+
+// Set the options.
+$parser
+  ->setResult($response_data)
+  ->setKeys($keys)
+  ->setLabelKey($label_key)
+  ->setHeaderSource($x_axis_grouping)
+  ->setTableAttributes($attributes)
+  ->setGroupKey($group_key);
+  ->parse();
+```
+GovCmsCkanDatasetParser.inc is well documented, see comments for what each setter does. You
+can also look at some of the visualisations used in govcms_ckan_display for working examples.
+
+Visualisation plugins
+---------------------
+Visualisations are cTools plugins, a module must implement the following for plugins to be registered:
+```
+function hook_ctools_plugin_directory($module, $plugin) {
+  if ($module == 'govcms_ckan' && in_array($plugin, array_keys(govcms_ckan_ctools_plugin_type()))) {
+    return 'plugins/' . $plugin;
+  }
+}
+```
+Visualisation plugins should live in the `plugins/visualisations` folder.
+
+The best place to start with creating a new visualisation is by copying a visualisation from
+`govcms_ckan_display/plugins/visualisation` to your own module/theme and the customise.
+
+Each plugin file should contain the following structure:
+```
+$plugin = array(
+  'title' => 'My visualisation title',
+  'settings' => array(),
+);
+function MODULE_NAME_PLUGIN_NAME_view($file, $display, $config){
+  // Return renderable array of visualisation.
+}
+function MODULE_NAME_PLUGIN_NAME_configure($plugin, $form, $form_state, $config){
+  // Return form structure array for configuration elements.
+}
+```
+
+Configuration helpers:
+
+There is a few helpers that include common structure/elements for visualisation configure forms.
+The intention is a plugin configuration form will include these as required.
+```
+// Get the key selection form elements.
+$key_elements = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
+
+// Get the axis configuraion elements.
+$axis_elements = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
+```

--- a/govcms_ckan.admin.inc
+++ b/govcms_ckan.admin.inc
@@ -47,8 +47,7 @@ function govcms_ckan_settings_form() {
 function govcms_ckan_settings_form_validate($form, &$form_state) {
   // If an API key is in use, enforce https.
   if (!empty($form_state['values']['govcms_ckan_api_key'])) {
-    $url_parts = parse_url($form_state['values']['govcms_ckan_endpoint_url']);
-    if ($url_parts['scheme'] != 'https') {
+    if (file_uri_scheme($form_state['values']['govcms_ckan_endpoint_url']) != 'https') {
       form_set_error('govcms_ckan_endpoint_url', t('If using an API key, the endpoint url must use HTTPS.'));
     }
   }

--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -164,11 +164,11 @@ function govcms_ckan_get_plugin_config_form($name, $form, $form_state, $config) 
 }
 
 /**
- * Helper function to return a specific visualisation plugin config form.
+ * Helper function to return a specific visualisation plugin view.
  *
  * @param string $name
  *   The name of the visualisation plugin to return.
- * @param array $file
+ * @param object $file
  *   The file object.
  * @param array $display
  *   The current display information and config.

--- a/modules/govcms_ckan_display/govcms_ckan_display.module
+++ b/modules/govcms_ckan_display/govcms_ckan_display.module
@@ -23,6 +23,16 @@ function govcms_ckan_display_theme($existing, $type, $theme, $path) {
       'file' => 'theme/govcms_ckan.theme.inc',
       'template' => 'theme/templates/govcms-ckan-empty-visualisation',
     ),
+    'ckan_display_table_wrapper' => array(
+      'variables' => array(
+        'tables' => array(),
+        'show_titles' => TRUE,
+        'content' => array(),
+        'classes_array' => array('ckan-display-table-wrapper'),
+      ),
+      'file' => 'theme/govcms_ckan.theme.inc',
+      'template' => 'theme/templates/govcms-ckan-display-table-wrapper',
+    ),
   );
 }
 

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -30,6 +30,8 @@
    * -- data-xTickCull: The max count of labels on the X axis
    * -- data-yTickCull: The max count of labels on the Y axis
    * -- data-yRound: The maximum amount of decimal places to allow in the Y axis ticks
+   * -- data-exportWidth: The width of the exported png. @see chartExport()
+   * -- data-exportHeight: The height of the exported png. @see chartExport()
    * - Table headings (th) is used as the label and the following attributes can be used
    * -- data-color: Hex colour, alternative to using palette on the table element.
    * -- data-style: The style for the line (dashed, solid)
@@ -98,8 +100,8 @@
       xTickCull: null,
       yTickCull: null,
       stacked: false,
-      exportWidth: null,
-      exportHeight: null,
+      exportWidth: '',
+      exportHeight: '',
       yRound: 4,
       // The data for the chart.
       columns: [],
@@ -337,7 +339,12 @@
           .html('Download as ' + format)
           .insertAfter(self.$toggle)
           .addClass(self.settings.component + '--download')
-          .chartExport({format: format, svg: self.$chart});
+          .chartExport({
+            format: format,
+            svg: self.$chart,
+            width: self.settings.exportWidth,
+            height: self.settings.exportHeight
+          });
       });
 
       // Return self for chaining.
@@ -478,8 +485,7 @@
     return this.each(function (i, dom) {
       // Store all the charts on the page in tableCharts.
       // Each chart needs a unique ID for the page.
-      // TODO: Consider alternative way of creating a chartId, will get conflicts if called multiple times.
-      settings.chartId = i;
+      settings.chartId = window.tableCharts.length + 1;
       window.tableCharts.push(
         new TableChart(dom, settings)
       );

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -75,8 +75,12 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       $parser->setGroupKey($config['split']);
     }
 
-    // Parse the data into tables.
-    $element = $parser->parse();
+    // Return the parsed tables in a wrapper.
+    $element = array(
+      '#theme' => 'ckan_display_table_wrapper',
+      '#tables' => $parser->parse(),
+      '#show_titles' => !empty($config['split']),
+    );
 
     // Add the JS to the tables.
     govcms_ckan_display_attach_charts($element, '.' . $chart_class);

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -9,9 +9,15 @@ $plugin = array(
   'settings' => array(
     'rotated' => 'false',
     'stacked' => 0,
+    'grid' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
-    'grid' => NULL,
+    'axis_settings' => array(
+      'x_tick_count' => NULL,
+      'y_tick_count' => NULL,
+      'x_tick_cull' => NULL,
+      'y_tick_cull' => NULL,
+    ),
   ),
 );
 
@@ -43,12 +49,12 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-grid' => $config['grid'],
       'data-xLabel' => $config['x_label'],
       'data-yLabel' => $config['y_label'],
+      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
+      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
+      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-xTickCount' => $config['x_tick_count'],
-      'data-yTickCount' => $config['y_tick_count'],
-      'data-xTickCull' => $config['x_tick_cull'],
-      'data-yTickCull' => $config['y_tick_cull'],
       'data-palette' => $config['palette'],
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
@@ -98,20 +104,8 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
 
   $config_form['stacked'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Is this this stacked'),
+    '#title' => t('Is this stacked'),
     '#default_value' => $config['stacked'],
-  );
-
-  $config_form['x_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('X axis label'),
-    '#default_value' => $config['x_label'],
-  );
-
-  $config_form['y_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Y axis label'),
-    '#default_value' => $config['y_label'],
   );
 
   $config_form['grid'] = array(
@@ -125,6 +119,10 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
       'xy' => t('Both X and Y lines'),
     ),
   );
+
+  // Add axis settings.
+  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
+  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -76,8 +76,13 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       $parser->setGroupKey($config['split']);
     }
 
-    // Parse the data into tables.
-    $element = $parser->parse();
+
+    // Return the parsed tables in a wrapper.
+    $element = array(
+      '#theme' => 'ckan_display_table_wrapper',
+      '#tables' => $parser->parse(),
+      '#show_titles' => !empty($config['split']),
+    );
 
     // Add the JS to the tables.
     govcms_ckan_display_attach_charts($element, '.' . $chart_class);

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -10,9 +10,15 @@ $plugin = array(
     'rotated' => 'false',
     'area' => 0,
     'show_labels' => 0,
+    'grid' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
-    'grid' => NULL,
+    'axis_settings' => array(
+      'x_tick_count' => NULL,
+      'y_tick_count' => NULL,
+      'x_tick_cull' => NULL,
+      'y_tick_cull' => NULL,
+    ),
   ),
 );
 
@@ -44,12 +50,12 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-grid' => $config['grid'],
       'data-xLabel' => $config['x_label'],
       'data-yLabel' => $config['y_label'],
+      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
+      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
+      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-xTickCount' => $config['x_tick_count'],
-      'data-yTickCount' => $config['y_tick_count'],
-      'data-xTickCull' => $config['x_tick_cull'],
-      'data-yTickCull' => $config['y_tick_cull'],
       'data-palette' => $config['palette'],
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
@@ -109,18 +115,6 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
     '#default_value' => $config['show_labels'],
   );
 
-  $config_form['x_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('X axis label'),
-    '#default_value' => $config['x_label'],
-  );
-
-  $config_form['y_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Y axis label'),
-    '#default_value' => $config['y_label'],
-  );
-
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
@@ -132,6 +126,10 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
       'xy' => t('Both X and Y lines'),
     ),
   );
+
+  // Add axis settings.
+  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
+  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -76,8 +76,12 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       $parser->setGroupKey($config['split']);
     }
 
-    // Parse the data into tables.
-    $element = $parser->parse();
+    // Return the parsed tables in a wrapper.
+    $element = array(
+      '#theme' => 'ckan_display_table_wrapper',
+      '#tables' => $parser->parse(),
+      '#show_titles' => !empty($config['split']),
+    );
 
     // Add the JS to the tables.
     govcms_ckan_display_attach_charts($element, '.' . $chart_class);

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -10,9 +10,15 @@ $plugin = array(
     'rotated' => 'false',
     'area' => 0,
     'show_labels' => 0,
+    'grid' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
-    'grid' => NULL,
+    'axis_settings' => array(
+      'x_tick_count' => NULL,
+      'y_tick_count' => NULL,
+      'x_tick_cull' => NULL,
+      'y_tick_cull' => NULL,
+    ),
   ),
 );
 
@@ -44,12 +50,12 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-grid' => $config['grid'],
       'data-xLabel' => $config['x_label'],
       'data-yLabel' => $config['y_label'],
+      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
+      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
+      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-xTickCount' => $config['x_tick_count'],
-      'data-yTickCount' => $config['y_tick_count'],
-      'data-xTickCull' => $config['x_tick_cull'],
-      'data-yTickCull' => $config['y_tick_cull'],
       'data-palette' => $config['palette'],
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
@@ -109,18 +115,6 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
     '#default_value' => $config['show_labels'],
   );
 
-  $config_form['x_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('X axis label'),
-    '#default_value' => $config['x_label'],
-  );
-
-  $config_form['y_label'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Y axis label'),
-    '#default_value' => $config['y_label'],
-  );
-
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
@@ -132,6 +126,10 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
       'xy' => t('Both X and Y lines'),
     ),
   );
+
+  // Add axis settings.
+  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
+  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/theme/govcms_ckan.theme.inc
+++ b/modules/govcms_ckan_display/theme/govcms_ckan.theme.inc
@@ -14,3 +14,42 @@ function template_preprocess_ckan_empty_visualisation(&$variables) {
     $variables['empty_text'] = variable_get('govcms_ckan_display_empty_visualisation_text', $default_text);
   }
 }
+
+/**
+ * Implements hook_preprocess_ckan_display_table_wrapper().
+ *
+ * Provides both wrappers and optional titles for rendered ckan tables.
+ */
+function template_preprocess_ckan_display_table_wrapper(&$variables) {
+  // If tables aren't an array we abort. Possibly due to parsing error.
+  if (!is_array($variables['tables'])) {
+    return;
+  }
+
+  // It is assumed that the key for each table is the title.
+  foreach ($variables['tables'] as $title => $table) {
+    // Wrapper container.
+    $wrapper = array(
+      '#type' => 'container',
+      '#attributes' => array('class' => array('ckan-display-table')),
+    );
+
+    // If we are showing the title for each table.
+    if ($variables['show_titles']) {
+      $wrapper['title'] = array(
+        '#theme' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => filter_xss($title),
+      );
+    }
+
+    // Add the table.
+    $wrapper['table'] = $table;
+
+    // Add to content.
+    $variables['content'][] = $wrapper;
+  }
+
+  // Indicate if there is titles with a wrapper class.
+  $variables['classes_array'][] = ($variables['show_titles'] ? 'with' : 'without') . '-titles';
+}

--- a/modules/govcms_ckan_display/theme/templates/govcms-ckan-display-table-wrapper.tpl.php
+++ b/modules/govcms_ckan_display/theme/templates/govcms-ckan-display-table-wrapper.tpl.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @file
+ * A wrapper for ckan tables.
+ */
+?>
+<div class="<?php print $classes; ?>">
+  <?php print render($content); ?>
+</div>

--- a/modules/govcms_ckan_media/govcms_ckan_media.install
+++ b/modules/govcms_ckan_media/govcms_ckan_media.install
@@ -56,7 +56,9 @@ function _govcms_ckan_media_create_config_field($entity_type, $bundle) {
     $field = array(
       'field_name' => $field_name,
       'type' => 'govcms_ckan_media_config',
+      'module' => 'govcms_ckan_media',
       'cardinality' => 1,
+      'entity_types' => array('file'),
     );
     $field = field_create_field($field);
   }

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -220,6 +220,11 @@ function _govcms_ckan_media_field_widget_visualisation_options() {
   return $options;
 }
 
+
+/******************************
+ * Config form default elements.
+ ******************************/
+
 /**
  * This helper provides the common elements for selecting the keys.
  *
@@ -290,18 +295,18 @@ function govcms_ckan_media_visualisation_default_key_config($form, $form_state, 
     '#title' => t('X Axis Grouping'),
     '#options' => array(
       'keys' => t('Group by keys'),
-      'values' => t('Group by values'),
+      'values' => t('Group by label values'),
     ),
     '#default_value' => isset($config['x_axis_grouping']) ? $config['x_axis_grouping'] : 'keys',
-    '#description' => t('Will the x axis be keys or values.'),
+    '#description' => t('Will the x axis be keys or values of the label key.'),
   );
 
   $form['labels'] = array(
     '#type' => 'select',
-    '#title' => t('Labels'),
+    '#title' => t('Label key'),
     '#options' => $options['all'],
     '#default_value' => $config['labels'],
-    '#description' => t('What field contains the labels.'),
+    '#description' => t('What key contains the labels.'),
   );
 
   $form['split'] = array(
@@ -320,4 +325,77 @@ function govcms_ckan_media_visualisation_default_key_config($form, $form_state, 
   );
 
   return $form;
+}
+
+/**
+ * This helper provides the common elements for graph display axis settings.
+ *
+ * Eg: labels, tick counts, etc.
+ *
+ * @param array $form
+ *   Form array for the parent form.
+ * @param array $form_state
+ *   Current form state array from the parent form.
+ * @param array $config
+ *   The current configuration values.
+ *
+ * @return array
+ *   Form structure for new elements.
+ */
+function govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config = array()) {
+  $element = array();
+
+  // Labels.
+  $element['x_label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('X axis label'),
+    '#default_value' => $config['x_label'],
+  );
+  $element['y_label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Y axis label'),
+    '#default_value' => $config['y_label'],
+  );
+
+  // Advanced settings.
+  $element['axis_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced axis settings'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  // Limit tick count.
+  $element['axis_settings']['x_tick_count'] = array(
+    '#title' => t('X Tick Count'),
+    '#type' => 'textfield',
+    '#default_value' => $config['axis_settings']['x_tick_count'],
+    '#element_validate' => array('element_validate_integer'),
+    '#description' => t('The number of ticks on the X axis.'),
+  );
+  $element['axis_settings']['y_tick_count'] = array(
+    '#title' => t('Y Tick Count'),
+    '#type' => 'textfield',
+    '#default_value' => $config['axis_settings']['y_tick_count'],
+    '#element_validate' => array('element_validate_integer'),
+    '#description' => t('The number of ticks on the Y axis.'),
+  );
+
+  // Limit label count.
+  $element['axis_settings']['x_tick_cull'] = array(
+    '#title' => t('X Label Count'),
+    '#type' => 'textfield',
+    '#default_value' => $config['axis_settings']['x_tick_cull'],
+    '#element_validate' => array('element_validate_integer'),
+    '#description' => t('The max number of labels on the Xaxis.'),
+  );
+  $element['axis_settings']['y_tick_cull'] = array(
+    '#title' => t('Y Label Count'),
+    '#type' => 'textfield',
+    '#default_value' => $config['axis_settings']['y_tick_cull'],
+    '#element_validate' => array('element_validate_integer'),
+    '#description' => t('The max number of labels on the Y axis.'),
+  );
+
+  return $element;
 }

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
@@ -111,46 +111,16 @@ function govcms_ckan_media_field_formatter_settings_form($field, $instance, $vie
   $element['export_width'] = array(
     '#title' => t('Width'),
     '#type' => 'textfield',
-    '#default_value' => $settings['width'],
+    '#default_value' => $settings['export_width'],
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('A pixel value (without unit). Applied when exporting as an image.'),
+    '#description' => t('A pixel value (without unit). Applied when exporting as an image. Leave blank for auto sizing.'),
   );
   $element['export_height'] = array(
     '#title' => t('Height'),
     '#type' => 'textfield',
-    '#default_value' => $settings['height'],
+    '#default_value' => $settings['export_height'],
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('A pixel value (without unit). Applied when exporting as an image.'),
-  );
-
-  $element['x_tick_count'] = array(
-    '#title' => t('X Tick Count'),
-    '#type' => 'textfield',
-    '#default_value' => $settings['x_tick_count'],
-    '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The number of ticks on the X axis.'),
-  );
-  $element['y_tick_count'] = array(
-    '#title' => t('Y Tick Count'),
-    '#type' => 'textfield',
-    '#default_value' => $settings['y_tick_count'],
-    '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The number of ticks on the Y axis.'),
-  );
-
-  $element['x_tick_cull'] = array(
-    '#title' => t('X Label Count'),
-    '#type' => 'textfield',
-    '#default_value' => $settings['x_tick_cull'],
-    '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The max number of labels on the Xaxis.'),
-  );
-  $element['y_tick_cull'] = array(
-    '#title' => t('Y Label Count'),
-    '#type' => 'textfield',
-    '#default_value' => $settings['y_tick_cull'],
-    '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The max number of labels on the Y axis.'),
+    '#description' => t('A pixel value (without unit). Applied when exporting as an image. Leave blank for auto sizing.'),
   );
 
   // TODO: Add validator.

--- a/src/GovCmsCkanClient.inc
+++ b/src/GovCmsCkanClient.inc
@@ -101,8 +101,8 @@ class GovCmsCkanClient {
     $test_url = url(
       $this->apiUrl . $this->apiPath() . $resource,
       array(
-	'external' => TRUE,
-	'query' => $query,
+        'external' => TRUE,
+        'query' => $query,
       ));
 
     // Add authentication.
@@ -146,8 +146,8 @@ class GovCmsCkanClient {
     $this->url = url(
       $this->apiUrl . $this->apiPath() . $this->resource,
       array(
-	'external' => TRUE,
-	'query' => $this->query,
+        'external' => TRUE,
+        'query' => $this->query,
       ));
 
     // If no cache, we do a new request, parse and cache it.
@@ -155,7 +155,7 @@ class GovCmsCkanClient {
     if ($this->cacheDataGet() === FALSE) {
       // Make the request.
       $this->response = drupal_http_request($this->url, array(
-	'headers' => array('Authorization' => $this->apiKey),
+        'headers' => array('Authorization' => $this->apiKey),
       ));
 
       // Parse the response.
@@ -187,8 +187,12 @@ class GovCmsCkanClient {
       // TODO: Autodetect response format and handle errors if not JSON?
       $data = json_decode($this->response->data);
       $this->responseObject->data = $data->result;
+      // There is a possibility that we get a 200 code but failed request.
+      // @see http://docs.ckan.org/en/latest/api/#making-an-api-request
+      $this->responseObject->valid = $data->success;
     }
-    else {
+
+    if (!$this->responseObject->valid) {
       $this->errorLogger();
     }
   }
@@ -218,9 +222,9 @@ class GovCmsCkanClient {
     watchdog('govcms_ckan_client',
       'Error requesting data from CKAN endpont: @url - Error @code - @status',
       array(
-	'@url' => $this->url,
-	'@code' => $this->response->code,
-	'@status' => $this->response->status_message,
+        '@url' => $this->url,
+        '@code' => $this->response->code,
+        '@status' => $this->response->status_message,
       ),
       WATCHDOG_ERROR);
   }


### PR DESCRIPTION
* Solves ENV-257 with the ability to define the export size for a PNG image. This is set in the display formatter settings (so common site wide)
* Moved axis tick/label limiting into the visualisation settings so can be set on a per dataset basis, but re-usable via a helper (like the key settings)
* Fixed stacked checkbox label
* Fixed bug with adding multiple charts to a page when not done all at the same time
* Slight label changes for some key selection form elements to make it more obvious as to what they do
* Added wrappers to visualisation to assist with theming
* Added titles to visualisation if they are grouped/split
* used `file_uri_scheme()` to get scheme in https validate
* Added additional check to client to ensure CKAN response is `success: true`