### PR TITLE
Use a different endpoint for anon vs. authenticated validation.

### DIFF
--- a/govcms_ckan.admin.inc
+++ b/govcms_ckan.admin.inc
@@ -58,8 +58,13 @@ function govcms_ckan_settings_form_validate($form, &$form_state) {
     $form_state['values']['govcms_ckan_endpoint_url'],
     $form_state['values']['govcms_ckan_api_key']);
 
-  // Test the connection using action/package_list resource.
-  $response_code = $client->testConnection('action/dashboard_activity_list', array('limit' => 1));
+  // Test the connection for a valid response.
+  if (!empty($form_state['values']['govcms_ckan_api_key'])) {
+    $response_code = $client->testConnection('action/dashboard_activity_list', array('limit' => 1));
+  }
+  else {
+    $response_code = $client->testConnection('action/package_list', array('limit' => 1));
+  }
 
   // If we don't get a 200 (success), we have problems connecting.
   if ($response_code != 200) {


### PR DESCRIPTION
Resolve non-auth access to a CKAN endpoint.