### PR TITLE
Allow filtering CKAN datastore on key/value or query string.

### DIFF
--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -211,9 +211,19 @@ function govcms_ckan_client() {
  * @return object
  *   A client response object.
  */
-function govcms_ckan_client_request_records($resource_id = NULL) {
+function govcms_ckan_client_request_records($resource_id = NULL, $search = NULL, $filters = NULL) {
   $client = govcms_ckan_client();
-  return $client->get('action/datastore_search', array('id' => $resource_id));
+  $query = array('id' => $resource_id);
+
+  if (!empty($search)) {
+    $query += array('q' => $search);
+  }
+
+  if (!empty ($filters)) {
+    $query += array('filters' => $filters);
+  }
+
+  return $client->get('action/datastore_search', $query);
 }
 
 /**

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -18,6 +18,10 @@ $plugin = array(
       'x_tick_cull' => NULL,
       'y_tick_cull' => NULL,
     ),
+    'ckan_filters' => array(
+      'search' => NULL,
+      'filters' => NULL,
+    ),
   ),
 );
 
@@ -27,7 +31,9 @@ $plugin = array(
 function govcms_ckan_display_bar_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-bar-chart';
-  $response = govcms_ckan_client_request_records($file->resource_id);
+  $ckan_search = $config['ckan_filters']['search'];
+  $ckan_filters = $config['ckan_filters']['filters'];
+  $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
   if ($response->valid === FALSE) {

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -19,6 +19,10 @@ $plugin = array(
       'x_tick_cull' => NULL,
       'y_tick_cull' => NULL,
     ),
+    'ckan_filters' => array(
+      'search' => NULL,
+      'filters' => NULL,
+    ),
   ),
 );
 
@@ -28,7 +32,9 @@ $plugin = array(
 function govcms_ckan_display_line_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-line-chart';
-  $response = govcms_ckan_client_request_records($file->resource_id);
+  $ckan_search = $config['ckan_filters']['search'];
+  $ckan_filters = $config['ckan_filters']['filters'];
+  $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
   if ($response->valid === FALSE) {

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -19,6 +19,10 @@ $plugin = array(
       'x_tick_cull' => NULL,
       'y_tick_cull' => NULL,
     ),
+    'ckan_filters' => array(
+      'search' => NULL,
+      'filters' => NULL,
+    ),
   ),
 );
 
@@ -28,7 +32,9 @@ $plugin = array(
 function govcms_ckan_display_spline_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-spline-chart';
-  $response = govcms_ckan_client_request_records($file->resource_id);
+  $ckan_search = $config['ckan_filters']['search'];
+  $ckan_filters = $config['ckan_filters']['filters'];
+  $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
   if ($response->valid === FALSE) {

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -279,6 +279,44 @@ function govcms_ckan_media_visualisation_default_key_config($form, $form_state, 
     $options['all'][$field->id] = $field->id;
   }
 
+  // Optional filter and query parameters.
+  $form['ckan_filters'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('CKAN data filters'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  // Default values for query string.
+  if (isset($config['ckan_filters']['search'])) {
+    $ckan_query_default = $config['ckan_filters']['search'];
+  }
+  else {
+    $ckan_query_default = '';
+  }
+
+  $form['ckan_filters']['search'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Full text query'),
+    '#description' => t('Optionally query entire dataset for any string value.'),
+    '#default_value' => $ckan_query_default,
+  );
+
+  // Default values for key/value filters.
+  if (isset($config['ckan_filters']['filters'])) {
+    $ckan_filters_default = $config['ckan_filters']['filters'];
+  }
+  else {
+    $ckan_filters_default = '';
+  }
+
+  $form['ckan_filters']['filters'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Filters'),
+    '#description' => t('Filter on key/value dictionary. For example: {"code": "4000", "year": "2016"}.'),
+    '#default_value' => $ckan_filters_default,
+  );
+
   // Build the elements.
   $form['keys'] = array(
     '#type' => 'checkboxes',

--- a/modules/govcms_ckan_media/plugins/visualisation/table.inc
+++ b/modules/govcms_ckan_media/plugins/visualisation/table.inc
@@ -6,6 +6,10 @@
 
 $plugin = array(
   'title' => t('Table visualisation'),
+  'ckan_filters' => array(
+    'search' => NULL,
+    'filters' => NULL,
+  ),
 );
 
 /**
@@ -15,7 +19,7 @@ function govcms_ckan_media_table_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-table';
   $parser = govcms_ckan_dataset_parser();
-  $response = govcms_ckan_client_request_records($file->resource_id);
+  $response = govcms_ckan_client_request_records($file->resource_id, $config['ckan_filters']['search'], $config['ckan_filters']['filters']);
 
   // If failure, provide error message.
   if ($response->valid !== FALSE) {


### PR DESCRIPTION
Allow for restricting result set returned from CKAN by:
- Query string (full text search)
- Filters (dictionary of key/value pairs, e.g: {"Postal_Code": "4066", "Age", "18"}

Makes the module more useful on large datasets.