### PR TITLE
Add palette override per graph.

### DIFF
--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -10,6 +10,7 @@ $plugin = array(
     'rotated' => 'false',
     'stacked' => 0,
     'grid' => NULL,
+    'palette_override' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
     'axis_settings' => array(
@@ -55,7 +56,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-palette' => $config['palette'],
+      'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
     );
@@ -110,6 +111,13 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
     '#type' => 'checkbox',
     '#title' => t('Is this stacked'),
     '#default_value' => $config['stacked'],
+  );
+
+  $config_form['palette_override'] = array(
+    '#title' => t('Palette override'),
+    '#type' => 'textfield',
+    '#default_value' => $config['palette_override'],
+    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -11,6 +11,7 @@ $plugin = array(
     'area' => 0,
     'show_labels' => 0,
     'grid' => NULL,
+    'palette_override' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
     'axis_settings' => array(
@@ -56,7 +57,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-palette' => $config['palette'],
+      'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
     );
@@ -118,6 +119,13 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
     '#default_value' => $config['show_labels'],
+  );
+
+  $config_form['palette_override'] = array(
+    '#title' => t('Palette override'),
+    '#type' => 'textfield',
+    '#default_value' => $config['palette_override'],
+    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -11,6 +11,7 @@ $plugin = array(
     'area' => 0,
     'show_labels' => 0,
     'grid' => NULL,
+    'palette_override' => NULL,
     'x_label' => NULL,
     'y_label' => NULL,
     'axis_settings' => array(
@@ -56,7 +57,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
-      'data-palette' => $config['palette'],
+      'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
       'data-exportWidth' => $config['export_width'],
       'data-exportHeight' => $config['export_height'],
     );
@@ -117,6 +118,13 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
     '#default_value' => $config['show_labels'],
+  );
+
+  $config_form['palette_override'] = array(
+    '#title' => t('Palette override'),
+    '#type' => 'textfield',
+    '#default_value' => $config['palette_override'],
+    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(


### PR DESCRIPTION
Optionally provide comma separated hex values per visualisation to override global settings.