### PR TITLE
Allow all keys to be displayed in a table.

### DIFF
--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -241,7 +241,7 @@ function _govcms_ckan_media_field_widget_visualisation_options() {
  * @return array
  *   Form structure for new elements.
  */
-function govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config = array()) {
+function govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config = array(), $key_type = 'numeric') {
   $form = array();
 
   // We need a resource_id, however this file might not be saved yet, if it is
@@ -283,7 +283,7 @@ function govcms_ckan_media_visualisation_default_key_config($form, $form_state, 
   $form['keys'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Keys'),
-    '#options' => $options['numeric'],
+    '#options' => $options[$key_type],
     '#default_value' => $config['keys'],
     '#multiple' => TRUE,
     '#required' => TRUE,

--- a/modules/govcms_ckan_media/plugins/visualisation/table.inc
+++ b/modules/govcms_ckan_media/plugins/visualisation/table.inc
@@ -46,6 +46,12 @@ function govcms_ckan_media_table_view($file, $display, $config) {
  * Configure form callback.
  */
 function govcms_ckan_media_table_configure($plugin, $form, $form_state, $config) {
+  // Get default key elements.
+  $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config, 'all');
+
+  // Allow for an empty selection on label key.
+  $config_form['labels']['#empty_option'] = t('None');
+
   // Return basic key configuration.
-  return govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
+  return $config_form;
 }

--- a/src/GovCmsCkanDatasetParser.inc
+++ b/src/GovCmsCkanDatasetParser.inc
@@ -323,6 +323,12 @@ class GovCmsCkanDatasetParser {
       $row = array();
       // For each key.
       foreach ($keys as $key) {
+        // If label key is disabled ignore the 'none' key and continue.
+        if (empty($key)) {
+	  $row[] = NULL;
+          continue;
+        }
+
         // If it is a label key, it forms an x tick cell, otherwise data.
         $row[] = $this->labelKey == $key ? $this->createHeaderCell('row', $record->{$key}) : $record->{$key};
       }


### PR DESCRIPTION
This allows non-numeric key selection and makes `Label key` optional when using the base Table visualisation to allow a 1:1 representation of data in CKAN.

<img width="637" alt="screen shot 2016-04-05 at 1 25 34 pm" src="https://cloud.githubusercontent.com/assets/1256274/14270486/f4253cfe-fb31-11e5-8792-70ff1db96e55.png">
