### PR TITLE
Option to choose bar width.

### DIFF
--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -105,6 +105,7 @@
       exportWidth: '',
       exportHeight: '',
       yRound: 4,
+      barWidth: 0.5,
       // The data for the chart.
       columns: [],
       data: {},
@@ -114,7 +115,7 @@
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
         'xTickCount', 'yTickCount', 'xTickCull', 'yTickCull', 'stacked', 'exportWidth', 'exportHeight',
-        'yRound'],
+        'barWidth', 'yRound'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',
@@ -483,6 +484,11 @@
       case 'y':
         options.grid = {y: {show: true}};
         break;
+    }
+
+    // Provide a width ratio for bars.
+    if (settings.type == 'bar') {
+      options.bar = {width: {ratio: settings.barWidth}}
     }
 
     // Create chart.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -7,6 +7,7 @@
 $plugin = array(
   'title' => t('Bar chart'),
   'settings' => array(
+    'bar_width' => 0.5,
     'rotated' => 'false',
     'stacked' => 0,
     'show_labels' => 0,
@@ -53,6 +54,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-type' => 'bar',
 
       // Entity settings.
+      'data-barWidth' => $config['bar_width'],
       'data-rotated' => $config['rotated'],
       'data-stacked' => ($config['stacked'] == 1 ? 'true' : 'false'),
       'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
@@ -121,6 +123,17 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
     '#default_value' => $config['show_labels'],
+  );
+
+  $config_form['bar_width'] = array(
+    '#type' => 'select',
+    '#title' => t('Bar width'),
+    '#default_value' => $config['bar_width'],
+    '#options' => array(
+      '0.5' => t('Standard'),
+      '0.3' => t('Thin'),
+      '0.75' => t('Thick'),
+    ),
   );
 
   $config_form['stacked'] = array(


### PR DESCRIPTION
New thin/thick/standard options on bar chart visualisation.

Target:
![unnamed-1](https://cloud.githubusercontent.com/assets/1256274/14413673/930cf56e-ffc4-11e5-84f4-c957f7584d44.gif)

Actual (with #27) + CSS:
<img width="467" alt="screen shot 2016-04-11 at 8 53 32 am" src="https://cloud.githubusercontent.com/assets/1256274/14413675/9fbb91f8-ffc4-11e5-926b-204c1f17ad61.png">
