### PR TITLE
Allow custom http-auth headers

### DIFF
--- a/govcms_ckan.admin.inc
+++ b/govcms_ckan.admin.inc
@@ -34,6 +34,16 @@ function govcms_ckan_settings_form() {
     '#default_value' => variable_get('govcms_ckan_api_key', ''),
   );
 
+  $form['govcms_ckan_auth_header'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Authorisation header'),
+    '#description' => t('Optionally override the HTTP authorisation header if required.'),
+    '#weight' => 2,
+    '#size' => 100,
+    '#required' => FALSE,
+    '#default_value' => variable_get('govcms_ckan_auth_header', ''),
+  );
+
   $form['#validate'][] = 'govcms_ckan_settings_form_validate';
 
   return system_settings_form($form);
@@ -56,7 +66,8 @@ function govcms_ckan_settings_form_validate($form, &$form_state) {
   module_load_include('inc', 'govcms_ckan', 'src/GovCmsCkanClient');
   $client = new GovCmsCkanClient(
     $form_state['values']['govcms_ckan_endpoint_url'],
-    $form_state['values']['govcms_ckan_api_key']);
+    $form_state['values']['govcms_ckan_api_key'],
+    $form_state['values']['govcms_ckan_auth_header']);
 
   // Test the connection for a valid response.
   if (!empty($form_state['values']['govcms_ckan_api_key'])) {

--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -199,7 +199,8 @@ function govcms_ckan_client() {
   module_load_include('inc', 'govcms_ckan', 'src/GovCmsCkanClient');
   $base_url = variable_get('govcms_ckan_endpoint_url', '');
   $api_key = variable_get('govcms_ckan_api_key', '');
-  return new GovCmsCkanClient($base_url, $api_key);
+  $auth_header = variable_get('govcms_ckan_auth_header', 'Authorization');
+  return new GovCmsCkanClient($base_url, $api_key, $auth_header);
 }
 
 /**

--- a/src/GovCmsCkanClient.inc
+++ b/src/GovCmsCkanClient.inc
@@ -5,7 +5,7 @@
  *
  * Basic Example Usage.
  * --------------------
- * $client = new GovCmsCkanClient($base_url, $api_key);
+ * $client = new GovCmsCkanClient($base_url, $api_key, $auth_header);
  * $client->get('action/package_show', array('id' => 'fd49dc83f86f'));
  *
  * Response Object.
@@ -31,6 +31,7 @@ class GovCmsCkanClient {
    */
   private $apiUrl;
   private $apiKey;
+  private $authHeader;
   private $apiPath = '/api/%d/';
   private $apiVersion = 3;
 
@@ -79,9 +80,10 @@ class GovCmsCkanClient {
    * @param int $api_version
    *   The version of the API to use.
    */
-  public function __construct($base_url, $api_key = NULL, $api_version = 3) {
+  public function __construct($base_url, $api_key = NULL, $auth_header = "Authorization", $api_version = 3) {
     $this->apiUrl = $base_url;
     $this->apiKey = $api_key;
+    $this->authHeader = $auth_header;
     $this->apiVersion = $api_version;
   }
 
@@ -108,7 +110,7 @@ class GovCmsCkanClient {
     // Add authentication.
     $options = array();
     if (!empty($this->apiKey)) {
-      $options = array('headers' => array('Authorization' => $this->apiKey));
+      $options = array('headers' => array($this->authHeader => $this->apiKey));
     }
 
     // Return TRUE if response code is 200 (OK).
@@ -155,7 +157,7 @@ class GovCmsCkanClient {
     if ($this->cacheDataGet() === FALSE) {
       // Make the request.
       $this->response = drupal_http_request($this->url, array(
-        'headers' => array('Authorization' => $this->apiKey),
+        'headers' => array($this->authHeader => $this->apiKey),
       ));
 
       // Parse the response.


### PR DESCRIPTION
Not all CKAN instances allow access using the default `Authorization` http header. This branch allows configuration of the HTTP header to use for auth (e.g `X-CKAN-API-Key`).

See CKAN [docs](http://docs.ckan.org/en/latest/maintaining/configuration.html#apikey-header-name).
