### PR TITLE
Fixed issue with some chart settings not being detected due to case mismatch

### DIFF
--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -151,7 +151,7 @@
       // Available settings are found in the dataAttributes setting. We loop through
       // each of those and if not empty, override the settings.
       $(self.settings.dataAttributes).each(function (i, attr) {
-        val = self.settings.$dom.data(attr);
+        val = self.settings.$dom.data(attr.toLowerCase());
         if (val !== undefined && val !== null && val !== '') {
           self.settings[attr] = val;
         }

--- a/src/GovCmsCkanDatasetParser.inc
+++ b/src/GovCmsCkanDatasetParser.inc
@@ -203,6 +203,20 @@ class GovCmsCkanDatasetParser {
   }
 
   /**
+   * Normalises attributes so all keys are lowercase.
+   *
+   * @return array
+   *   An array of attributes.
+   */
+  public function normaliseAttributes($attributes) {
+    $attrs = array();
+    foreach ($attributes as $key => $value) {
+      $attrs[strtolower($key)] = $value;
+    }
+    return $attrs;
+  }
+
+  /**
    * Return the unique labels for a given key.
    *
    * @param string $key
@@ -250,7 +264,7 @@ class GovCmsCkanDatasetParser {
 
       // Add any additional attributes and a generic class.
       $this->tableAttributes['class'][] = 'govcms-ckan-table';
-      $tables[$group_key]['attributes'] = $this->tableAttributes;
+      $tables[$group_key]['attributes'] = $this->normaliseAttributes($this->tableAttributes);
     }
 
     // Format for renderable array if required.
@@ -324,7 +338,7 @@ class GovCmsCkanDatasetParser {
     }
     elseif ($scope == 'col' && !empty($this->columnAttributes[$value])) {
       // Add any additional column attributes.
-      $cell = array_merge($cell, $this->columnAttributes[$value]);
+      $cell = array_merge($cell, $this->normaliseAttributes($this->columnAttributes[$value]));
     }
     return $cell;
   }


### PR DESCRIPTION
Hey @srowlands 

Another one bites the dust -> ENV-308.  

This actually fixed a few more bugs we didn't notice before too (eg. axis labels & rotate not working).
