### PR TITLE
Remove stroke on bars on export.

### DIFF
--- a/modules/govcms_ckan_display/js/jquery.chart_export.js
+++ b/modules/govcms_ckan_display/js/jquery.chart_export.js
@@ -48,7 +48,7 @@
       height: '',
       // Include c3js styles (fixes display bugs with c3js charts)
       includeC3jsStyles: true,
-      c3jsStyles: 'svg{font:10px sans-serif}line,path{fill:none;stroke:#000}',
+      c3jsStyles: 'svg{font:10px sans-serif}line,path{fill:none;stroke:#000}.c3-bar{stroke:none!important}',
       // Passed Validation requirements.
       valid: true,
       // Error message.


### PR DESCRIPTION
Enforce no-stroke on bars when exporting (fixes #46)
