### PR TITLE
Fixed X label culling on C3 charts, removed Y label culling as is not supported by C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ streamline publishing, sharing, finding and using data.
 Authors
 -------
 This module was created by [Jeremy Graham](https://github.com/jeremy-doghouse) @ [Doghouse Agency](http://doghouse.agency)
-for [GovCMS](https://www.govcms.gov.au/) with lots of help and guidance from [Acquia](https://www.acquia.com/)
+for [GovCMS](https://www.govcms.gov.au/) with assistance and guidance from [Acquia](https://www.acquia.com/)
 and [these contributors](https://github.com/govCMS/govcms-ckan/graphs/contributors).
 
 Submodules

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -107,8 +107,7 @@
       xTickRotate: 0,
       xTickCount: null,
       yTickCount: null,
-      xTickCull: null,
-      yTickCull: null,
+      xTickCull: false,
       stacked: false,
       exportWidth: '',
       exportHeight: '',
@@ -122,7 +121,7 @@
       xLabels: ['x'],
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
-        'xTickCount', 'yTickCount', 'xTickCull', 'yTickCull', 'stacked', 'exportWidth', 'exportHeight',
+        'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight',
         'barWidth', 'yRound', 'showTitle', 'title'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
@@ -449,11 +448,12 @@
     }
 
     // Define the tick label culling (max labels).
-    if (settings.xTickCull) {
+    if (settings.xTickCull !== false) {
       axis.x.tick.culling = {max: parseInt(settings.xTickCull)};
-    }
-    if (settings.yTickCull) {
-      axis.y.tick.culling = {max: parseInt(settings.yTickCull)};
+      // Round labels to whole numbers.
+      axis.x.tick.format = function (x) {
+        return Math.round(x);
+      };
     }
 
     // Perform rounding on Y axis values.
@@ -466,8 +466,10 @@
     if (settings.xLabels.length > 1) {
       settings.data.x = 'x';
       settings.data.columns.push(settings.xLabels);
-      // this needed to load string x value
-      axis.x.type = 'category';
+      // Tick culling prevents this being a category axis.
+      if (settings.xTickCull === false) {
+        axis.x.type = 'category';
+      }
     }
 
     // Show labels on data points?
@@ -512,8 +514,8 @@
     }
 
     // Provide a width ratio for bars.
-    if (settings.type == 'bar') {
-      options.bar = {width: {ratio: settings.barWidth}}
+    if (settings.type === 'bar') {
+      options.bar = {width: {ratio: settings.barWidth}};
     }
 
     // Create chart.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -22,7 +22,6 @@ $plugin = array(
       'x_tick_count' => NULL,
       'y_tick_count' => NULL,
       'x_tick_cull' => NULL,
-      'y_tick_cull' => NULL,
     ),
     'ckan_filters' => array(
       'search' => NULL,
@@ -70,7 +69,6 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-xTickCount' => $config['axis_settings']['x_tick_count'],
       'data-yTickCount' => $config['axis_settings']['y_tick_count'],
       'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
-      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -21,7 +21,6 @@ $plugin = array(
       'x_tick_count' => NULL,
       'y_tick_count' => NULL,
       'x_tick_cull' => NULL,
-      'y_tick_cull' => NULL,
     ),
     'ckan_filters' => array(
       'search' => NULL,
@@ -67,7 +66,6 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-xTickCount' => $config['axis_settings']['x_tick_count'],
       'data-yTickCount' => $config['axis_settings']['y_tick_count'],
       'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
-      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -21,7 +21,6 @@ $plugin = array(
       'x_tick_count' => NULL,
       'y_tick_count' => NULL,
       'x_tick_cull' => NULL,
-      'y_tick_cull' => NULL,
     ),
     'ckan_filters' => array(
       'search' => NULL,
@@ -67,7 +66,6 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-xTickCount' => $config['axis_settings']['x_tick_count'],
       'data-yTickCount' => $config['axis_settings']['y_tick_count'],
       'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
-      'data-yTickCull' => $config['axis_settings']['y_tick_cull'],
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -481,18 +481,11 @@ function govcms_ckan_media_visualisation_default_axis_config($form, $form_state,
 
   // Limit label count.
   $element['axis_settings']['x_tick_cull'] = array(
-    '#title' => t('X Label Count'),
+    '#title' => t('Maximum X label count'),
     '#type' => 'textfield',
     '#default_value' => $config['axis_settings']['x_tick_cull'],
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The max number of labels on the Xaxis.'),
-  );
-  $element['axis_settings']['y_tick_cull'] = array(
-    '#title' => t('Y Label Count'),
-    '#type' => 'textfield',
-    '#default_value' => $config['axis_settings']['y_tick_cull'],
-    '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The max number of labels on the Y axis.'),
+    '#description' => t('The number of X labels will be adjusted to <strong>less than this value</strong>.<br /><strong>NOTE: This will only work if the X axis labels are numbers</strong> as maths is used to reduce the label count.<br />Labels will be rounded to nearest whole number.'),
   );
 
   return $element;


### PR DESCRIPTION
Hey @srowlands 

This solves ENV-331, x labels being flagged as a 'category' prevented x-culling. Also found that c3 doesn't support y-culling (y-tick-count should handle that anyway) so have removed y-culling from the settings form and the js.
