### PR TITLE
Visualisation updates and cleanup

### DIFF
--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -252,3 +252,36 @@ function govcms_ckan_string_to_array($string) {
   }
   return $values;
 }
+
+/**
+ * A helper to abstract settings from a config array or object.
+ *
+ * This prevents the need for having issets everywhere when retrieving config
+ * values that potentially do not exist in a config array. Eg newly added keys
+ * that might not be in the database for existing content.
+ *
+ * @param mixed $config
+ *   A config array or object.
+ * @param string $key
+ *   The key to retrieve the settings from, you can use a slash to get nested
+ *   values. Eg 'label/overrides' would retrieve $config['label']['overrides'].
+ * @param mixed $default_value
+ *   A fallback if no setting found.
+ *
+ * @return mixed
+ *   The config value.
+ */
+function govcms_ckan_get_config_value($config, $key, $default_value = NULL) {
+  $config = is_object($config) ? (array) $config : $config;
+  $keys = explode('/', $key);
+  $value = $default_value;
+  foreach ($keys as $depth => $val) {
+    if (($depth + 1) == count($keys) && isset($config[$val])) {
+      $value = $config[$val];
+    }
+    else {
+      $config = isset($config[$val]) ? (array) $config[$val] : array();
+    }
+  }
+  return $value;
+}

--- a/modules/govcms_ckan_display/govcms_ckan_display.module
+++ b/modules/govcms_ckan_display/govcms_ckan_display.module
@@ -64,6 +64,12 @@ function govcms_ckan_display_library() {
       ),
       array(
         'type' => 'file',
+        'data' => $module_path . '/js/table_charts.c3js.js',
+        'group' => JS_LIBRARY,
+        'preprocess' => FALSE,
+      ),
+      array(
+        'type' => 'file',
         'data' => $module_path . '/js/govcms_ckan_display.js',
         'group' => JS_LIBRARY,
         'preprocess' => FALSE,

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -23,6 +23,8 @@
    * -- data-defaultView: Should the chart or table be displayed first. Defaults to 'chart'.
    * -- data-palette: A comma separated list of hex colours to be used for the palette.
    * -- data-grid: Grid lines to use: xy, x or y
+   * -- data-hidePoints: Default is false, gives the ability to hide points. Only applies to line/spline.
+   * -- data-pointSize: Define the point size, default is 2.5
    * -- data-showTitle : Should a title be rendered within the chart
    * -- data-title : The title string
    * -- data-xLabel: The optional label to show on the X axis
@@ -103,6 +105,7 @@
       showTitle: false,
       title: null,
       hidePoints: false,
+      pointSize: 2.5,
       xLabel: null,
       yLabel: null,
       xTickRotate: 0,
@@ -123,7 +126,7 @@
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
         'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight',
-        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints'],
+        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -112,6 +112,8 @@
       xTickCount: null,
       yTickCount: null,
       xTickCull: false,
+      xAxisLabelPos: 'inner-right',
+      yAxisLabelPos: 'inner-top',
       stacked: false,
       exportWidth: '',
       exportHeight: '',
@@ -126,7 +128,7 @@
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
         'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight',
-        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize'],
+        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize', 'xAxisLabelPos', 'yAxisLabelPos'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -62,7 +62,7 @@
   /*
    * Storage for the chart classes available.
    */
-  var tableChartsChart = {};
+  window.tableChartsChart = window.tableChartsChart || {};
 
   /**
    * tableChart class.
@@ -102,6 +102,7 @@
       grid: null,
       showTitle: false,
       title: null,
+      hidePoints: false,
       xLabel: null,
       yLabel: null,
       xTickRotate: 0,
@@ -122,7 +123,7 @@
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
         'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight',
-        'barWidth', 'yRound', 'showTitle', 'title'],
+        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',
@@ -390,136 +391,6 @@
 
     // Return self for chaining.
     return self;
-  };
-
-  /**
-   * The tableCharts c3js implementation.
-   *
-   * @param settings
-   *   The parsed settings from tableCharts.
-   *
-   * TODO: If this gets to large, move to its own file.
-   */
-  tableChartsChart.c3js = function (settings) {
-    // Ensure library is loaded.
-    if (typeof c3 === 'undefined') {
-      alert('c3js library not found');
-      return;
-    }
-
-    // Type of chart is stored in the data.
-    settings.data.type = settings.type;
-
-    // Placeholder for the data columns.
-    settings.data.columns = [];
-
-    // Stacked can be applied to most charts, the stack order used is
-    // the column order.
-    if (settings.stacked) {
-      settings.data.groups = [settings.group];
-    }
-
-    // Apply styles (currently only works with lines and dashes)
-    if (settings.styles.length) {
-      settings.data.regions = {};
-      $(settings.styles).each(function (i, d){
-        settings.data.regions[d.set] = [{style: d.style}];
-      });
-    }
-
-    // Define the axis settings.
-    var axis = {
-      rotated: settings.rotated,
-      x: {label: settings.xLabel, tick: {}},
-      y: {label: settings.yLabel, tick: {}}
-    };
-
-    // Define the tick rotation.
-    if (settings.xTickRotate != 0) {
-      axis.x.tick.rotate = parseInt(settings.xTickRotate);
-    }
-
-    // Define the tick counts.
-    if (settings.xTickCount) {
-      axis.x.tick.count = parseInt(settings.xTickCount);
-    }
-    if (settings.yTickCount) {
-      axis.y.tick.count = parseInt(settings.yTickCount);
-    }
-
-    // Define the tick label culling (max labels).
-    if (settings.xTickCull !== false) {
-      axis.x.tick.culling = {max: parseInt(settings.xTickCull)};
-      // Round labels to whole numbers.
-      axis.x.tick.format = function (x) {
-        return Math.round(x);
-      };
-    }
-
-    // Perform rounding on Y axis values.
-    axis.y.tick.format = function (y) {
-      var places = Math.pow(10, parseInt(settings.yRound));
-      return Math.round(y * places) / places;
-    };
-
-    // Add X axis labels.
-    if (settings.xLabels.length > 1) {
-      settings.data.x = 'x';
-      settings.data.columns.push(settings.xLabels);
-      // Tick culling prevents this being a category axis.
-      if (settings.xTickCull === false) {
-        axis.x.type = 'category';
-      }
-    }
-
-    // Show labels on data points?
-    settings.data.labels = settings.labels;
-
-    // Add any overrides to graph types based on the column.
-    settings.data.types = settings.types;
-    settings.data.colors = settings.paletteOverride;
-
-    // Add the data columns.
-    $(settings.columns).each(function (i, col) {
-      settings.data.columns.push(col);
-    });
-
-    // Options structure to be passed to c3
-    var options = {
-      bindto: '#' + settings.chartDomId,
-      data: settings.data,
-      axis: axis,
-      color: {
-        pattern: settings.palette
-      },
-      oninit: settings.chartInitCallback
-    };
-
-    // Add optional grid lines.
-    switch (settings.grid) {
-      case 'xy':
-        options.grid = {x: {show: true}, y: {show: true}};
-        break;
-      case 'x':
-        options.grid = {x: {show: true}};
-        break;
-      case 'y':
-        options.grid = {y: {show: true}};
-        break;
-    }
-
-    // Add optional title.
-    if (settings.showTitle) {
-      options.title = {text: settings.title};
-    }
-
-    // Provide a width ratio for bars.
-    if (settings.type === 'bar') {
-      options.bar = {width: {ratio: settings.barWidth}};
-    }
-
-    // Create chart.
-    c3.generate(options);
   };
 
   /**

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -1,0 +1,229 @@
+(function ($) {
+  /*
+   * This is the c3js implementation class for tableCharts.
+   *
+   * It is called by the tableCharts class and assumes data has been parsed from
+   * the table and all applicable settings and data are present.
+   *
+   * @see tableCharts default settings for structure and available settings.
+   *
+   * @param settings
+   *   The parsed settings from tableCharts.
+   */
+
+  // All tableCharts chart implementations should be a method of this object.
+  window.tableChartsChart = window.tableChartsChart || {};
+
+  tableChartsChart.c3js = function (settings) {
+
+    // Ensure library is loaded.
+    if (typeof c3 === 'undefined') {
+      alert('c3js library not found');
+      return;
+    }
+
+    // Self instance.
+    var self = this;
+
+    // Store settings pased from parser.
+    self.settings = settings;
+
+    // Base options object that gets passed to c3js.
+    self.options = {
+      bindto: '#' + self.settings.chartDomId,
+      color: {pattern: self.settings.palette},
+      oninit: self.settings.chartInitCallback,
+      data: {},
+      axis: {}
+    };
+
+    /*
+     * Initialize the C3 Chart.
+     */
+    self.init = function () {
+      // Parse all the settings.
+      self
+        .parseDataOptions()
+        .parseAxisOptions()
+        .parseGridOptions()
+        .parsePointOptions()
+        .parseBarOptions()
+        .parseChartOptions();
+
+      // Create chart.
+      c3.generate(self.options);
+    };
+
+    /*
+     * Parse data and data settings.
+     */
+    self.parseDataOptions = function () {
+      var data = {};
+
+      // Type of chart is stored in the data.
+      data.type = self.settings.type;
+
+      // Placeholder for the data columns.
+      data.columns = [];
+
+      // Stacked can be applied to most charts, the stack order used is
+      // the column order.
+      if (self.settings.stacked) {
+        data.groups = [self.settings.group];
+      }
+
+      // Apply styles (currently only works with lines and dashes)
+      if (self.settings.styles.length) {
+        data.regions = {};
+        $(self.settings.styles).each(function (i, d){
+          data.regions[d.set] = [{style: d.style}];
+        });
+      }
+
+      // Add X axis labels.
+      if (self.settings.xLabels.length > 1) {
+        data.x = 'x';
+        data.columns.push(self.settings.xLabels);
+      }
+
+      // Show labels on data points?
+      data.labels = self.settings.labels;
+
+      // Add any overrides to graph types based on the column.
+      data.types = self.settings.types;
+      data.colors = self.settings.paletteOverride;
+
+      // Add the data columns.
+      $(self.settings.columns).each(function (i, col) {
+        data.columns.push(col);
+      });
+
+      // Add to options.
+      self.options.data = data;
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse the axis options.
+     */
+    self.parseAxisOptions = function () {
+      // Define the axis settings.
+      var axis = {
+        rotated: settings.rotated,
+        x: {label: settings.xLabel, tick: {}},
+        y: {label: settings.yLabel, tick: {}}
+      };
+
+      // Define the tick rotation.
+      if (self.settings.xTickRotate !== 0) {
+        axis.x.tick.rotate = parseInt(self.settings.xTickRotate);
+      }
+
+      // Define the tick counts.
+      if (self.settings.xTickCount) {
+        axis.x.tick.count = parseInt(self.settings.xTickCount);
+      }
+      if (self.settings.yTickCount) {
+        axis.y.tick.count = parseInt(self.settings.yTickCount);
+      }
+
+      // Define the tick label culling (max labels).
+      if (self.settings.xTickCull !== false) {
+        axis.x.tick.culling = {max: parseInt(self.settings.xTickCull)};
+        // Round labels to whole numbers.
+        axis.x.tick.format = function (x) {
+          return Math.round(x);
+        };
+      }
+
+      // Perform rounding on Y axis values.
+      axis.y.tick.format = function (y) {
+        var places = Math.pow(10, parseInt(self.settings.yRound));
+        return Math.round(y * places) / places;
+      };
+
+      // Tick culling prevents this being a category axis.
+      if (self.settings.xLabels.length > 1 && self.settings.xTickCull === false) {
+        axis.x.type = 'category';
+      }
+
+      // Add to options.
+      self.options.axis = axis;
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse grid options.
+     */
+    self.parseGridOptions = function () {
+
+      switch (self.settings.grid) {
+        case 'xy':
+          self.options.grid = {x: {show: true}, y: {show: true}};
+          break;
+        case 'x':
+          self.options.grid = {x: {show: true}};
+          break;
+        case 'y':
+          self.options.grid = {y: {show: true}};
+          break;
+      }
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse point options.
+     */
+    self.parsePointOptions = function () {
+      var point = {};
+
+      // Optionally hide points from line/spline charts.
+      if (self.settings.hidePoints) {
+        point = {show: false};
+      }
+
+      self.options.point = point;
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse bar options.
+     */
+    self.parseBarOptions = function () {
+      if (self.settings.type === 'bar') {
+
+        // Provide a width ratio for bars.
+        self.options.bar = {width: {ratio: self.settings.barWidth}};
+      }
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse generic chart options.
+     */
+    self.parseChartOptions = function () {
+      // Add optional title.
+      if (self.settings.showTitle) {
+        self.options.title = {text: self.settings.title};
+      }
+
+      // Return self for chaining.
+      return self;
+    };
+
+    // Create the chart.
+    self.init();
+
+  };
+
+})(jQuery);

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -185,7 +185,12 @@
 
       // Optionally hide points from line/spline charts.
       if (self.settings.hidePoints) {
-        point = {show: false};
+        point.show = false;
+      }
+
+      // Optionally set the point size.
+      if (self.settings.pointSize) {
+        point.r = self.settings.pointSize;
       }
 
       self.options.point = point;

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -111,9 +111,9 @@
     self.parseAxisOptions = function () {
       // Define the axis settings.
       var axis = {
-        rotated: settings.rotated,
-        x: {label: settings.xLabel, tick: {}},
-        y: {label: settings.yLabel, tick: {}}
+        rotated: self.settings.rotated,
+        x: {label: {text: self.settings.xLabel}, tick: {}},
+        y: {label: {text: self.settings.yLabel}, tick: {}}
       };
 
       // Define the tick rotation.
@@ -147,6 +147,14 @@
       // Tick culling prevents this being a category axis.
       if (self.settings.xLabels.length > 1 && self.settings.xTickCull === false) {
         axis.x.type = 'category';
+      }
+
+      // Set the label positions.
+      if (self.settings.xAxisLabelPos) {
+        axis.x.label.position = self.settings.xAxisLabelPos;
+      }
+      if (self.settings.yAxisLabelPos) {
+        axis.y.label.position = self.settings.yAxisLabelPos;
       }
 
       // Add to options.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -17,7 +17,7 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
-    'label_options' => array(
+    'label_settings' => array(
       'overrides' => NULL,
     ),
     'axis_settings' => array(
@@ -52,7 +52,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
     // Setup our configuration.
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_options']['overrides']);
+    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
 
     // Attributes for the table.
     $attributes = array(

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -39,8 +39,8 @@ $plugin = array(
 function govcms_ckan_display_bar_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-bar-chart';
-  $ckan_search = $config['ckan_filters']['search'];
-  $ckan_filters = $config['ckan_filters']['filters'];
+  $ckan_search = govcms_ckan_get_config_value($config, 'ckan_filters/search');
+  $ckan_filters = govcms_ckan_get_config_value($config, 'ckan_filters/filters');
   $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
@@ -51,8 +51,8 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
 
     // Setup our configuration.
     $keys = array_filter($config['keys']);
-    $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
+    $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
+    $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
 
     // Attributes for the table.
     $attributes = array(
@@ -60,24 +60,26 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-type' => 'bar',
 
       // Entity settings.
-      'data-barWidth' => $config['bar_width'],
-      'data-rotated' => $config['rotated'],
-      'data-stacked' => ($config['stacked'] == 1 ? 'true' : 'false'),
-      'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
-      'data-grid' => $config['grid'],
-      'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
+      'data-barWidth' => govcms_ckan_get_config_value($config, 'bar_width'),
+      'data-rotated' => govcms_ckan_get_config_value($config, 'rotated'),
+      'data-stacked' => (govcms_ckan_get_config_value($config, 'stacked') == 1 ? 'true' : 'false'),
+      'data-labels' => (govcms_ckan_get_config_value($config, 'show_labels') == 1 ? 'true' : 'false'),
+      'data-grid' => govcms_ckan_get_config_value($config, 'grid'),
+      'data-showTitle' => (govcms_ckan_get_config_value($config, 'show_title') == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
-      'data-xLabel' => $config['x_label'],
-      'data-yLabel' => $config['y_label'],
-      'data-xTickRotate' => ($config['axis_settings']['x_tick_rotate'] == 1 ? '90' : '0'),
-      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
-      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
-      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-xLabel' => govcms_ckan_get_config_value($config, 'x_label'),
+      'data-yLabel' => govcms_ckan_get_config_value($config, 'y_label'),
+      'data-xTickRotate' => (govcms_ckan_get_config_value($config, 'axis_settings/x_tick_rotate') == 1 ? '90' : '0'),
+      'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
+      'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
+      'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
-      'data-exportWidth' => $config['export_width'],
-      'data-exportHeight' => $config['export_height'],
+      'data-exportWidth' => govcms_ckan_get_config_value($config, 'export_width'),
+      'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
+      'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
+      'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
     );
 
     // Parse the data.
@@ -119,7 +121,7 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
   $config_form['rotated'] = array(
     '#type' => 'select',
     '#title' => t('Orientation'),
-    '#default_value' => $config['rotated'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
     '#options' => array(
       'false' => t('Vertical'),
       'true' => t('Horizontal'),
@@ -129,13 +131,13 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
-    '#default_value' => $config['show_labels'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 
   $config_form['bar_width'] = array(
     '#type' => 'select',
     '#title' => t('Bar width'),
-    '#default_value' => $config['bar_width'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'bar_width'),
     '#options' => array(
       '0.5' => t('Standard'),
       '0.3' => t('Thin'),
@@ -146,20 +148,20 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, $form_state, $c
   $config_form['stacked'] = array(
     '#type' => 'checkbox',
     '#title' => t('Is this stacked'),
-    '#default_value' => $config['stacked'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'stacked'),
   );
 
   $config_form['palette_override'] = array(
     '#title' => t('Palette override'),
     '#type' => 'textfield',
-    '#default_value' => $config['palette_override'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
     '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
-    '#default_value' => $config['grid'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
     '#empty_option' => t('None'),
     '#options' => array(
       'x' => t('X Lines'),

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -10,13 +10,14 @@ $plugin = array(
     'rotated' => 'false',
     'area' => 0,
     'show_labels' => 0,
+    'hide_points' => 0,
     'grid' => NULL,
     'palette_override' => NULL,
     'show_title' => 1,
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
-    'label_options' => array(
+    'label_settings' => array(
       'overrides' => NULL,
     ),
     'axis_settings' => array(
@@ -51,7 +52,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
     // Setup our configuration.
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_options']['overrides']);
+    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
 
     // Attributes for the table.
     $attributes = array(
@@ -61,6 +62,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-type' => ($config['area'] == 1 ? 'area' : 'line'),
       'data-rotated' => $config['rotated'],
       'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
+      'data-hidePoints' => ($config['hide_points'] == 1 ? 'true' : 'false'),
       'data-grid' => $config['grid'],
       'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
@@ -133,6 +135,12 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
     '#default_value' => $config['show_labels'],
+  );
+
+  $config_form['hide_points'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Disable data points'),
+    '#default_value' => $config['hide_points'],
   );
 
   $config_form['palette_override'] = array(

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -39,8 +39,8 @@ $plugin = array(
 function govcms_ckan_display_line_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-line-chart';
-  $ckan_search = $config['ckan_filters']['search'];
-  $ckan_filters = $config['ckan_filters']['filters'];
+  $ckan_search = govcms_ckan_get_config_value($config, 'ckan_filters/search');
+  $ckan_filters = govcms_ckan_get_config_value($config, 'ckan_filters/filters');
   $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
@@ -51,32 +51,34 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
 
     // Setup our configuration.
     $keys = array_filter($config['keys']);
-    $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
+    $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
+    $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
 
     // Attributes for the table.
     $attributes = array(
       'class' => array('ckan-chart', $chart_class),
 
       // Entity settings.
-      'data-type' => ($config['area'] == 1 ? 'area' : 'line'),
-      'data-rotated' => $config['rotated'],
-      'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
-      'data-hidePoints' => ($config['hide_points'] == 1 ? 'true' : 'false'),
-      'data-grid' => $config['grid'],
-      'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
+      'data-type' => (govcms_ckan_get_config_value($config, 'area') == 1 ? 'area' : 'line'),
+      'data-rotated' => govcms_ckan_get_config_value($config, 'rotated'),
+      'data-labels' => (govcms_ckan_get_config_value($config, 'show_labels') == 1 ? 'true' : 'false'),
+      'data-hidePoints' => (govcms_ckan_get_config_value($config, 'hide_points') == 1 ? 'true' : 'false'),
+      'data-grid' => govcms_ckan_get_config_value($config, 'grid'),
+      'data-showTitle' => (govcms_ckan_get_config_value($config, 'show_title') == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
-      'data-xLabel' => $config['x_label'],
-      'data-yLabel' => $config['y_label'],
-      'data-xTickRotate' => ($config['axis_settings']['x_tick_rotate'] == 1 ? '90' : '0'),
-      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
-      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
-      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-xLabel' => govcms_ckan_get_config_value($config, 'x_label'),
+      'data-yLabel' => govcms_ckan_get_config_value($config, 'y_label'),
+      'data-xTickRotate' => (govcms_ckan_get_config_value($config, 'axis_settings/x_tick_rotate') == 1 ? '90' : '0'),
+      'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
+      'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
+      'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
-      'data-exportWidth' => $config['export_width'],
-      'data-exportHeight' => $config['export_height'],
+      'data-exportWidth' => govcms_ckan_get_config_value($config, 'export_width'),
+      'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
+      'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
+      'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
     );
 
     // Parse the data.
@@ -118,7 +120,7 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
   $config_form['rotated'] = array(
     '#type' => 'select',
     '#title' => t('Orientation'),
-    '#default_value' => $config['rotated'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
     '#options' => array(
       'false' => t('Vertical'),
       'true' => t('Horizontal'),
@@ -128,32 +130,32 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
   $config_form['area'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
-    '#default_value' => $config['area'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'area'),
   );
 
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
-    '#default_value' => $config['show_labels'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 
   $config_form['hide_points'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable data points'),
-    '#default_value' => $config['hide_points'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
 
   $config_form['palette_override'] = array(
     '#title' => t('Palette override'),
     '#type' => 'textfield',
-    '#default_value' => $config['palette_override'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
     '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
-    '#default_value' => $config['grid'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
     '#empty_option' => t('None'),
     '#options' => array(
       'x' => t('X Lines'),

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -16,6 +16,9 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'label_options' => array(
+      'overrides' => NULL,
+    ),
     'axis_settings' => array(
       'x_tick_rotate' => 0,
       'x_tick_count' => NULL,
@@ -48,6 +51,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
     // Setup our configuration.
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
+    $label_replacements = govcms_ckan_string_to_array($config['label_options']['overrides']);
 
     // Attributes for the table.
     $attributes = array(
@@ -79,6 +83,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
       ->setHeaderSource($config['x_axis_grouping'])
+      ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
       ->setColumnAttributes($column_overrides);
 

--- a/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
@@ -1,16 +1,15 @@
 <?php
 /**
  * @file
- * Line chart visualisation.
+ * Point chart visualisation.
  */
 
 $plugin = array(
-  'title' => t('Spline chart'),
+  'title' => t('Scatter Plot chart'),
   'settings' => array(
     'rotated' => 'false',
-    'area' => 0,
     'show_labels' => 0,
-    'hide_points' => 0,
+    'point_size' => 2.5,
     'grid' => NULL,
     'palette_override' => NULL,
     'show_title' => 1,
@@ -36,12 +35,10 @@ $plugin = array(
 /**
  * Returns a renderable array that represents the block content.
  */
-function govcms_ckan_display_spline_chart_view($file, $display, $config) {
+function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
   $element = array();
-  $chart_class = 'ckan-spline-chart';
-  $ckan_search = $config['ckan_filters']['search'];
-  $ckan_filters = $config['ckan_filters']['filters'];
-  $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
+  $chart_class = 'ckan-point-chart';
+  $response = govcms_ckan_client_request_records($file->resource_id, $config['ckan_filters']['search'], $config['ckan_filters']['filters']);
 
   // If failure, provide error message.
   if ($response->valid === FALSE) {
@@ -59,10 +56,10 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'class' => array('ckan-chart', $chart_class),
 
       // Entity settings.
-      'data-type' => ($config['area'] == 1 ? 'area-spline' : 'spline'),
+      'data-type' => 'scatter',
       'data-rotated' => $config['rotated'],
       'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
-      'data-hidePoints' => ($config['hide_points'] == 1 ? 'true' : 'false'),
+      'data-pointSize' => $config['point_size'],
       'data-grid' => $config['grid'],
       'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
@@ -108,13 +105,15 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
   return $element;
 }
 
+
 /**
  * Configure form callback.
  */
-function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state, $config) {
+function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, $form_state, $config) {
   // Get default key elements.
   $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
 
+  // Point chart specific settings.
   $config_form['rotated'] = array(
     '#type' => 'select',
     '#title' => t('Orientation'),
@@ -125,22 +124,17 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
     ),
   );
 
-  $config_form['area'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable area'),
-    '#default_value' => $config['area'],
-  );
-
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
     '#default_value' => $config['show_labels'],
   );
 
-  $config_form['hide_points'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Disable data points'),
-    '#default_value' => $config['hide_points'],
+  $config_form['point_size'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Point size'),
+    '#default_value' => $config['point_size'],
+    '#description' => t('Default point size is 2.5'),
   );
 
   $config_form['palette_override'] = array(
@@ -162,7 +156,7 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
     ),
   );
 
-  // Add axis settings.
+  // Axis settings.
   $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
   $config_form = array_merge($config_form, $axis_config_form);
 

--- a/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
@@ -37,8 +37,10 @@ $plugin = array(
  */
 function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
   $element = array();
-  $chart_class = 'ckan-point-chart';
-  $response = govcms_ckan_client_request_records($file->resource_id, $config['ckan_filters']['search'], $config['ckan_filters']['filters']);
+  $chart_class = 'ckan-scatter-plot-chart';
+  $ckan_search = govcms_ckan_get_config_value($config, 'ckan_filters/search');
+  $ckan_filters = govcms_ckan_get_config_value($config, 'ckan_filters/filters');
+  $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
   if ($response->valid === FALSE) {
@@ -48,8 +50,8 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
 
     // Setup our configuration.
     $keys = array_filter($config['keys']);
-    $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
+    $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
+    $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
 
     // Attributes for the table.
     $attributes = array(
@@ -57,23 +59,25 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
 
       // Entity settings.
       'data-type' => 'scatter',
-      'data-rotated' => $config['rotated'],
-      'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
-      'data-pointSize' => $config['point_size'],
-      'data-grid' => $config['grid'],
-      'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
+      'data-rotated' => govcms_ckan_get_config_value($config, 'rotated'),
+      'data-labels' => (govcms_ckan_get_config_value($config, 'show_labels') == 1 ? 'true' : 'false'),
+      'data-pointSize' => govcms_ckan_get_config_value($config, 'point_size'),
+      'data-grid' => govcms_ckan_get_config_value($config, 'grid'),
+      'data-showTitle' => (govcms_ckan_get_config_value($config, 'show_title') == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
-      'data-xLabel' => $config['x_label'],
-      'data-yLabel' => $config['y_label'],
-      'data-xTickRotate' => ($config['axis_settings']['x_tick_rotate'] == 1 ? '90' : '0'),
-      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
-      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
-      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-xLabel' => govcms_ckan_get_config_value($config, 'x_label'),
+      'data-yLabel' => govcms_ckan_get_config_value($config, 'y_label'),
+      'data-xTickRotate' => (govcms_ckan_get_config_value($config, 'axis_settings/x_tick_rotate') == 1 ? '90' : '0'),
+      'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
+      'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
+      'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
-      'data-exportWidth' => $config['export_width'],
-      'data-exportHeight' => $config['export_height'],
+      'data-exportWidth' => govcms_ckan_get_config_value($config, 'export_width'),
+      'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
+      'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
+      'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
     );
 
     // Parse the data.
@@ -117,7 +121,7 @@ function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, $form_
   $config_form['rotated'] = array(
     '#type' => 'select',
     '#title' => t('Orientation'),
-    '#default_value' => $config['rotated'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
     '#options' => array(
       'false' => t('Vertical'),
       'true' => t('Horizontal'),
@@ -127,27 +131,27 @@ function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, $form_
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
-    '#default_value' => $config['show_labels'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 
   $config_form['point_size'] = array(
     '#type' => 'textfield',
     '#title' => t('Point size'),
-    '#default_value' => $config['point_size'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'point_size'),
     '#description' => t('Default point size is 2.5'),
   );
 
   $config_form['palette_override'] = array(
     '#title' => t('Palette override'),
     '#type' => 'textfield',
-    '#default_value' => $config['palette_override'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
     '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
-    '#default_value' => $config['grid'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
     '#empty_option' => t('None'),
     '#options' => array(
       'x' => t('X Lines'),

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -16,6 +16,9 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'label_options' => array(
+      'overrides' => NULL,
+    ),
     'axis_settings' => array(
       'x_tick_rotate' => 0,
       'x_tick_count' => NULL,
@@ -48,6 +51,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
     // Setup our configuration.
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
+    $label_replacements = govcms_ckan_string_to_array($config['label_options']['overrides']);
 
     // Attributes for the table.
     $attributes = array(
@@ -79,6 +83,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
       ->setHeaderSource($config['x_axis_grouping'])
+      ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
       ->setColumnAttributes($column_overrides);
 

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -39,8 +39,8 @@ $plugin = array(
 function govcms_ckan_display_spline_chart_view($file, $display, $config) {
   $element = array();
   $chart_class = 'ckan-spline-chart';
-  $ckan_search = $config['ckan_filters']['search'];
-  $ckan_filters = $config['ckan_filters']['filters'];
+  $ckan_search = govcms_ckan_get_config_value($config, 'ckan_filters/search');
+  $ckan_filters = govcms_ckan_get_config_value($config, 'ckan_filters/filters');
   $response = govcms_ckan_client_request_records($file->resource_id, $ckan_search, $ckan_filters);
 
   // If failure, provide error message.
@@ -51,32 +51,34 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
 
     // Setup our configuration.
     $keys = array_filter($config['keys']);
-    $column_overrides = govcms_ckan_display_parse_column_overrides($config['column_overrides']);
-    $label_replacements = govcms_ckan_string_to_array($config['label_settings']['overrides']);
+    $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
+    $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
 
     // Attributes for the table.
     $attributes = array(
       'class' => array('ckan-chart', $chart_class),
 
       // Entity settings.
-      'data-type' => ($config['area'] == 1 ? 'area-spline' : 'spline'),
-      'data-rotated' => $config['rotated'],
-      'data-labels' => ($config['show_labels'] == 1 ? 'true' : 'false'),
-      'data-hidePoints' => ($config['hide_points'] == 1 ? 'true' : 'false'),
-      'data-grid' => $config['grid'],
-      'data-showTitle' => ($config['show_title'] == 1 ? 'true' : 'false'),
+      'data-type' => (govcms_ckan_get_config_value($config, 'area') == 1 ? 'area-spline' : 'spline'),
+      'data-rotated' => govcms_ckan_get_config_value($config, 'rotated'),
+      'data-labels' => (govcms_ckan_get_config_value($config, 'show_labels') == 1 ? 'true' : 'false'),
+      'data-hidePoints' => (govcms_ckan_get_config_value($config, 'hide_points') == 1 ? 'true' : 'false'),
+      'data-grid' => govcms_ckan_get_config_value($config, 'grid'),
+      'data-showTitle' => (govcms_ckan_get_config_value($config, 'show_title') == 1 ? 'true' : 'false'),
       'data-title' => $file->filename,
-      'data-xLabel' => $config['x_label'],
-      'data-yLabel' => $config['y_label'],
-      'data-xTickRotate' => ($config['axis_settings']['x_tick_rotate'] == 1 ? '90' : '0'),
-      'data-xTickCount' => $config['axis_settings']['x_tick_count'],
-      'data-yTickCount' => $config['axis_settings']['y_tick_count'],
-      'data-xTickCull' => $config['axis_settings']['x_tick_cull'],
+      'data-xLabel' => govcms_ckan_get_config_value($config, 'x_label'),
+      'data-yLabel' => govcms_ckan_get_config_value($config, 'y_label'),
+      'data-xTickRotate' => (govcms_ckan_get_config_value($config, 'axis_settings/x_tick_rotate') == 1 ? '90' : '0'),
+      'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
+      'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
+      'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
-      'data-exportWidth' => $config['export_width'],
-      'data-exportHeight' => $config['export_height'],
+      'data-exportWidth' => govcms_ckan_get_config_value($config, 'export_width'),
+      'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
+      'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
+      'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
     );
 
     // Parse the data.
@@ -118,7 +120,7 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
   $config_form['rotated'] = array(
     '#type' => 'select',
     '#title' => t('Orientation'),
-    '#default_value' => $config['rotated'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
     '#options' => array(
       'false' => t('Vertical'),
       'true' => t('Horizontal'),
@@ -128,7 +130,7 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
   $config_form['area'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
-    '#default_value' => $config['area'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'area'),
   );
 
   $config_form['show_labels'] = array(
@@ -140,20 +142,20 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
   $config_form['hide_points'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable data points'),
-    '#default_value' => $config['hide_points'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
 
   $config_form['palette_override'] = array(
     '#title' => t('Palette override'),
     '#type' => 'textfield',
-    '#default_value' => $config['palette_override'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
     '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
   );
 
   $config_form['grid'] = array(
     '#type' => 'select',
     '#title' => t('Enable grid'),
-    '#default_value' => $config['grid'],
+    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
     '#empty_option' => t('None'),
     '#options' => array(
       'x' => t('X Lines'),

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -392,18 +392,18 @@ function govcms_ckan_media_visualisation_default_key_config($form, $form_state, 
     );
   }
 
-  $form['label_options'] = array(
+  $form['label_settings'] = array(
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Label options'),
   );
 
-  $form['label_options']['overrides'] = array(
+  $form['label_settings']['overrides'] = array(
     '#type' => 'textarea',
     '#rows' => 2,
     '#title' => t('Label overrides'),
-    '#default_value' => isset($config['label_options']['overrides']) ? $config['label_options']['overrides'] : NULL,
+    '#default_value' => isset($config['label_settings']['overrides']) ? $config['label_settings']['overrides'] : NULL,
     '#description' => t('Optionally override one or more labels. Add one original_label|new_label per line and separate with a pipe. This will apply to X axis labels and legend labels.'),
   );
 

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
@@ -61,10 +61,8 @@ function govcms_ckan_media_field_formatter_info() {
         'export_width' => NULL,
         'export_height' => NULL,
         'palette' => NULL,
-        'x_tick_count' => NULL,
-        'y_tick_count' => NULL,
-        'x_tick_cull' => NULL,
-        'y_tick_cull' => NULL,
+        'x_axis_label_position' => 'inner-right',
+        'y_axis_label_position' => 'inner-top',
       ),
     ),
   );
@@ -129,6 +127,34 @@ function govcms_ckan_media_field_formatter_settings_form($field, $instance, $vie
     '#type' => 'textfield',
     '#default_value' => $settings['palette'],
     '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
+  );
+
+  $element['x_axis_label_position'] = array(
+    '#title' => t('X axis label position'),
+    '#type' => 'select',
+    '#default_value' => $settings['x_axis_label_position'],
+    '#options' => array(
+      'inner-right' => t('Inner right'),
+      'inner-center' => t('Inner center'),
+      'inner-left' => t('Inner left'),
+      'outer-right' => t('Outer right'),
+      'outer-center' => t('Outer center'),
+      'outer-left' => t('Outer left'),
+    ),
+  );
+
+  $element['y_axis_label_position'] = array(
+    '#title' => t('Y axis label position'),
+    '#type' => 'select',
+    '#default_value' => $settings['y_axis_label_position'],
+    '#options' => array(
+      'inner-top' => t('Inner top'),
+      'inner-middle' => t('Inner middle'),
+      'inner-bottom' => t('Inner bottom'),
+      'outer-top' => t('Outer top'),
+      'outer-middle' => t('Outer middle'),
+      'outer-bottom' => t('Outer bottom'),
+    ),
   );
 
   return $element;


### PR DESCRIPTION
Hi @srowlands sorry this one is a bit biggish but was time to do a bit of housekeeping :)

Cleanup:
- Moved c3js chart implementation into its own file
- Added methods to c3js implementation to improve readability and group related parsing. eg data, axis, point, etc.
- Added a new function to cleanly extract config values from config arrays that potentially don't exist due to settings saved as serialised data. This prevents the need for issets everywhere and suppresses any notices that appear on older charts (missing new settings)
- Added label replacements to all visualisations, missed in #51

New Features
- ENV-350 - Ability to toggle points on line/spline charts
- ENV-349 - Added Scatter Plot chart visualisation
- ENV-332 - Ability to override the default axis label position globally
