### PR TITLE
Tick position and opacity option

### DIFF
--- a/modules/govcms_ckan_display/css/govcms_ckan_display.css
+++ b/modules/govcms_ckan_display/css/govcms_ckan_display.css
@@ -1,0 +1,7 @@
+/* Styles that relate to custom functionality for display_charts and c3js */
+
+/* Styles that need to be embedded in a chart export */
+svg.chart-export{font:10px sans-serif}.chart-export line,.chart-export path{fill:none;stroke:#999}.chart-export .c3-bar{stroke:none!important}.chart-export .c3-chart-lines path {stroke: none}
+
+/* Area opacity */
+.tc-area-opacity-10 .c3-area {opacity: 0.10;}.tc-area-opacity-20 .c3-area {opacity: 0.20;}.tc-area-opacity-30 .c3-area {opacity: 0.30;}.tc-area-opacity-40 .c3-area {opacity: 0.40;}.tc-area-opacity-50 .c3-area {opacity: 0.50;}.tc-area-opacity-60 .c3-area {opacity: 0.60;}.tc-area-opacity-70 .c3-area {opacity: 0.70;}.tc-area-opacity-80 .c3-area {opacity: 0.80;}.tc-area-opacity-90 .c3-area {opacity: 0.90;}.tc-area-opacity-100 .c3-area {opacity: 1;}

--- a/modules/govcms_ckan_display/govcms_ckan_display.module
+++ b/modules/govcms_ckan_display/govcms_ckan_display.module
@@ -75,6 +75,12 @@ function govcms_ckan_display_library() {
         'preprocess' => FALSE,
       ),
     ),
+    'css' => array(
+      'type' => 'file',
+      'data' => $module_path . '/css/govcms_ckan_display.css',
+      'group' => CSS_DEFAULT,
+      'preprocess' => FALSE,
+    ),
   );
 
   // External Libraries (c3js & filesaver).
@@ -150,6 +156,8 @@ function govcms_ckan_display_library() {
  *   NULL then only the libraries will be added.
  */
 function govcms_ckan_display_add_charts($table_selector = NULL) {
+  // Module path.
+  $module_path = drupal_get_path('module', 'govcms_ckan_display');
   // Include c3js library.
   drupal_add_library('govcms_ckan_display', 'c3js');
   // Include filesaver library.
@@ -157,11 +165,13 @@ function govcms_ckan_display_add_charts($table_selector = NULL) {
   // Include custom chart libs.
   drupal_add_library('govcms_ckan_display', 'govcms_ckan_charts');
 
-  // Add the selector to drupal settings.
   if (!is_null($table_selector)) {
     drupal_add_js(array(
       'govcmsCkanDisplay' => array(
+        // Add the selector to drupal settings.
         'tableChartSelectors' => array($table_selector),
+        // Add the path to the stylesheet that gets embedded in an export.
+        'exportStylesheet' => url($module_path . '/css/govcms_ckan_display.css'),
       ),
     ), 'setting');
   }
@@ -180,7 +190,8 @@ function govcms_ckan_display_add_charts($table_selector = NULL) {
  *   NULL then only the libraries will be added.
  */
 function govcms_ckan_display_attach_charts(&$element, $table_selector = NULL) {
-
+  // Module path.
+  $module_path = drupal_get_path('module', 'govcms_ckan_display');
   // Include c3js library.
   $element['#attached']['library'][] = array('govcms_ckan_display', 'c3js');
   // Include filesaver library.
@@ -188,11 +199,13 @@ function govcms_ckan_display_attach_charts(&$element, $table_selector = NULL) {
   // Include custom chart libs.
   $element['#attached']['library'][] = array('govcms_ckan_display', 'govcms_ckan_charts');
 
-  // Add the table selector the charts will attach to.
   if (!is_null($table_selector)) {
     $settings = array(
       'govcmsCkanDisplay' => array(
+        // Add the selector to drupal settings.
         'tableChartSelectors' => array($table_selector),
+        // Add the path to the stylesheet that gets embedded in an export.
+        'exportStylesheet' => url($module_path . '/css/govcms_ckan_display.css'),
       ),
     );
     $element['#attached']['js'][] = array('data' => $settings, 'type' => 'setting');

--- a/modules/govcms_ckan_display/js/govcms_ckan_display.js
+++ b/modules/govcms_ckan_display/js/govcms_ckan_display.js
@@ -17,8 +17,10 @@
       // Tables to act on.
       var $tables = $(settings.govcmsCkanDisplay.tableChartSelectors.join(','), context);
 
-      // Add tableCharts.
-      $tables.once('table-charts').tableCharts();
+      // Add tableCharts, including export stylesheets.
+      $tables.once('table-charts').tableCharts({
+        exportStylesheet: settings.govcmsCkanDisplay.exportStylesheet
+      });
 
     }
   };

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -34,6 +34,7 @@
    * -- data-yTickCount: The count of ticks on the Y axis
    * -- data-xTickCull: The max count of labels on the X axis
    * -- data-yTickCull: The max count of labels on the Y axis
+   * -- data-xTickCentered: Are the x ticks centered above labels.
    * -- data-yRound: The maximum amount of decimal places to allow in the Y axis ticks
    * -- data-exportWidth: The width of the exported png. @see chartExport()
    * -- data-exportHeight: The height of the exported png. @see chartExport()
@@ -112,11 +113,14 @@
       xTickCount: null,
       yTickCount: null,
       xTickCull: false,
+      xTickCentered: true,
       xAxisLabelPos: 'inner-right',
       yAxisLabelPos: 'inner-top',
       stacked: false,
       exportWidth: '',
       exportHeight: '',
+      exportStylesheet: null,
+      areaOpacity: 20,
       yRound: 4,
       barWidth: 0.5,
       // The data for the chart.
@@ -127,8 +131,9 @@
       xLabels: ['x'],
       // Data attributes automatically parsed from the table element.
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
-        'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight',
-        'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize', 'xAxisLabelPos', 'yAxisLabelPos'],
+        'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight', 'areaOpacity',
+        'xTickCentered', 'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize',
+        'xAxisLabelPos', 'yAxisLabelPos'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',
@@ -379,7 +384,8 @@
             format: format,
             svg: self.$chart,
             width: self.settings.exportWidth,
-            height: self.settings.exportHeight
+            height: self.settings.exportHeight,
+            exportStylesheet: self.settings.exportStylesheet
           });
       });
 

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -32,7 +32,9 @@
     self.options = {
       bindto: '#' + self.settings.chartDomId,
       color: {pattern: self.settings.palette},
-      oninit: self.settings.chartInitCallback,
+      oninit: function () {
+        self.postBuildCallback();
+      },
       data: {},
       axis: {}
     };
@@ -149,6 +151,11 @@
         axis.x.type = 'category';
       }
 
+      // X Axis tick centered.
+      if (self.settings.xTickCentered) {
+        axis.x.tick.centered = self.settings.xTickCentered;
+      }
+
       // Set the label positions.
       if (self.settings.xAxisLabelPos) {
         axis.x.label.position = self.settings.xAxisLabelPos;
@@ -232,6 +239,16 @@
 
       // Return self for chaining.
       return self;
+    };
+
+    /*
+     * Perform post chart creation tasks.
+     */
+    self.postBuildCallback = function () {
+      // Apply an opacity class to the svg. See govcms_ckan_display.css.
+      $('#' + self.settings.chartDomId + ' > svg').attr('class', 'tc-area-opacity-' + self.settings.areaOpacity);
+      // Execute any callbacks passed from tableCharts.
+      self.settings.chartInitCallback();
     };
 
     // Create the chart.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -80,6 +80,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
       'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
       'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
+      'data-xTickCentered' => (govcms_ckan_get_config_value($config, 'x_axis_tick_centered', 1) == 1 ? 'true' : 'false'),
     );
 
     // Parse the data.

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -17,6 +17,7 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'area_opacity' => 20,
     'label_settings' => array(
       'overrides' => NULL,
     ),
@@ -72,6 +73,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
+      'data-areaOpacity' => govcms_ckan_get_config_value($config, 'area_opacity', 20),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -79,6 +81,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
       'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
       'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
+      'data-xTickCentered' => (govcms_ckan_get_config_value($config, 'x_axis_tick_centered', 1) == 1 ? 'true' : 'false'),
     );
 
     // Parse the data.
@@ -131,6 +134,22 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, $form_state, $
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area'),
+  );
+
+  $area_opacity_options = array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
+  $config_form['area_opacity'] = array(
+    '#type' => 'select',
+    '#title' => t('Area Opacity'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'area_opacity'),
+    '#options' => array_combine($area_opacity_options, $area_opacity_options),
+    '#states' => array(
+      'visible' => array(
+        // This field is deeply nested so resorting to a fairly ugly selector
+        // if selector is not found the in the edge case that the lang or delta
+        // is different field will fallback to being visible anyway.
+        ':input#edit-ckan-visualisation-und-0-config-visualisation-config-area' => array('checked' => TRUE),
+      ),
+    ),
   );
 
   $config_form['show_labels'] = array(

--- a/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
@@ -78,6 +78,7 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
       'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
       'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
       'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
+      'data-xTickCentered' => (govcms_ckan_get_config_value($config, 'x_axis_tick_centered', 1) == 1 ? 'true' : 'false'),
     );
 
     // Parse the data.

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -17,6 +17,7 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'area_opacity' => 20,
     'label_settings' => array(
       'overrides' => NULL,
     ),
@@ -72,6 +73,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
+      'data-areaOpacity' => govcms_ckan_get_config_value($config, 'area_opacity', 20),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -79,6 +81,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-exportHeight' => govcms_ckan_get_config_value($config, 'export_height'),
       'data-xAxisLabelPos' => govcms_ckan_get_config_value($config, 'x_axis_label_position'),
       'data-yAxisLabelPos' => govcms_ckan_get_config_value($config, 'y_axis_label_position'),
+      'data-xTickCentered' => (govcms_ckan_get_config_value($config, 'x_axis_tick_centered', 1) == 1 ? 'true' : 'false'),
     );
 
     // Parse the data.
@@ -131,6 +134,22 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, $form_state,
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area'),
+  );
+
+  $area_opacity_options = array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
+  $config_form['area_opacity'] = array(
+    '#type' => 'select',
+    '#title' => t('Area Opacity'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'area_opacity'),
+    '#options' => array_combine($area_opacity_options, $area_opacity_options),
+    '#states' => array(
+      'visible' => array(
+        // This field is deeply nested so resorting to a fairly ugly selector
+        // if selector is not found the in the edge case that the lang or delta
+        // is different field will fallback to being visible anyway.
+        ':input#edit-ckan-visualisation-und-0-config-visualisation-config-area' => array('checked' => TRUE),
+      ),
+    ),
   );
 
   $config_form['show_labels'] = array(

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -470,6 +470,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, $form_state,
     '#title' => t('Advanced axis settings'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
+    '#tree' => TRUE,
   );
 
   // Tick settings.

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.formatters.inc
@@ -63,6 +63,7 @@ function govcms_ckan_media_field_formatter_info() {
         'palette' => NULL,
         'x_axis_label_position' => 'inner-right',
         'y_axis_label_position' => 'inner-top',
+        'x_axis_tick_centered' => 1,
       ),
     ),
   );
@@ -157,6 +158,14 @@ function govcms_ckan_media_field_formatter_settings_form($field, $instance, $vie
     ),
   );
 
+  $element['x_axis_tick_centered'] = array(
+    '#title' => t('Center X axis tick above label'),
+    '#description' => t('When enabled the tick will display directly above the label on a the X axis.'),
+    '#type' => 'checkbox',
+    '#default_value' => $settings['x_axis_tick_centered'],
+    '#value' => 1,
+  );
+
   return $element;
 }
 
@@ -166,10 +175,13 @@ function govcms_ckan_media_field_formatter_settings_form($field, $instance, $vie
 function govcms_ckan_media_field_formatter_settings_summary($field, $instance, $view_mode) {
   $display = $instance['display'][$view_mode];
   $summary = array();
+  // Use the form to populate the labels.
+  $form_state = array();
+  $config_form = govcms_ckan_media_field_formatter_settings_form($field, $instance, $view_mode, array(), $form_state);
   // Dynamically create summary from settings.
   foreach ($display['settings'] as $key => $value) {
     if (!empty($value)) {
-      $summary[] = $key . ': ' . filter_xss($value);
+      $summary[] = $config_form[$key]['#title'] . ': ' . filter_xss($value);
     }
   }
   return !empty($summary) ? implode('<br />', $summary) : t('Default display');


### PR DESCRIPTION
Hey @srowlands, this solves ENV-378
- Ability to toggle position of ticks on X axis (centred or above label)
- Ability to set area opacity for area-line, area-spline
- Improved embedding of styles in chart exports (svg/png) via external css
- minor fixes / improvements to chart export
