### PR TITLE
Tools to make edge case area charts work

### DIFF
--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -314,3 +314,27 @@ function govcms_ckan_json_encode_attribute($values = NULL) {
   }
   return NULL;
 }
+
+/**
+ * A helper to reduce an array to only valid rows based on a not empty key.
+ *
+ * Eg. If every item in an array requires a non empty 'value' key value then
+ * this will reduce the rows to only those valid rows.
+ *
+ * @param array $rows
+ *   The rows from config. Passed by reference.
+ * @param string $not_empty_key
+ *   The key to check its value is not empty.
+ *
+ * @return array
+ *   The valid rows.
+ */
+function govcms_ckan_array_valid_rows($rows, $not_empty_key = 'value') {
+  $array = array();
+  foreach ($rows as $row) {
+    if (!empty($row[$not_empty_key])) {
+      $array[] = $row;
+    }
+  }
+  return $array;
+}

--- a/modules/govcms_ckan_display/css/govcms_ckan_display.css
+++ b/modules/govcms_ckan_display/css/govcms_ckan_display.css
@@ -1,7 +1,10 @@
 /* Styles that relate to custom functionality for display_charts and c3js */
 
 /* Styles that need to be embedded in a chart export */
-svg.chart-export{font:10px sans-serif}.chart-export line,.chart-export path{fill:none;stroke:#999}.chart-export .c3-bar{stroke:none!important}.chart-export .c3-chart-lines path {stroke: none}
+svg.chart-export{font:10px sans-serif}.chart-export line,.chart-export path{fill:none;stroke:#999}.chart-export .c3-bar{stroke:none!important}.chart-export .c3-chart-lines path {stroke: none}.chart-export .c3-chart {fill: #ffffff;} .chart-export .c3-chart > .c3-event-rects {fill-opacity: 1 !important;}
 
 /* Area opacity */
 .tc-area-opacity-10 .c3-area {opacity: 0.10;}.tc-area-opacity-20 .c3-area {opacity: 0.20;}.tc-area-opacity-30 .c3-area {opacity: 0.30;}.tc-area-opacity-40 .c3-area {opacity: 0.40;}.tc-area-opacity-50 .c3-area {opacity: 0.50;}.tc-area-opacity-60 .c3-area {opacity: 0.60;}.tc-area-opacity-70 .c3-area {opacity: 0.70;}.tc-area-opacity-80 .c3-area {opacity: 0.80;}.tc-area-opacity-90 .c3-area {opacity: 0.90;}.tc-area-opacity-100 .c3-area {opacity: 1;}
+
+/* Column override helper classes */
+.c3-target-hide-points .c3-circles {display: none;}

--- a/modules/govcms_ckan_display/js/jquery.chart_export.js
+++ b/modules/govcms_ckan_display/js/jquery.chart_export.js
@@ -173,7 +173,9 @@
     self.savePNG = function () {
       // Create a new image and add the svg as a src.
       var image = new Image();
-      image.src = 'data:image/svg+xml;base64,' + btoa(self.svgHtml);
+
+      // Unescape/encodeURIComponent solves issues with non utf-8 strings.
+      image.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(self.svgHtml)));
 
       // On image load, trigger its download with html5 download attr.
       image.onload = function () {

--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -36,6 +36,8 @@
    * -- data-yTickCull: The max count of labels on the Y axis
    * -- data-xTickCentered: Are the x ticks centered above labels.
    * -- data-yRound: The maximum amount of decimal places to allow in the Y axis ticks
+   * -- data-disableChartInteraction: Disable hover values on the chart. Default false.
+   * -- data-disableLegendInteraction: Prevent hover/click defaults on legend. Default false
    * -- data-exportWidth: The width of the exported png. @see chartExport()
    * -- data-exportHeight: The height of the exported png. @see chartExport()
    * - Table headings (th) is used as the label and the following attributes can be used
@@ -102,6 +104,8 @@
       paletteOverride: {},
       labels: false,
       styles: [],
+      disabledLegends: [],
+      dataClasses: {},
       grid: null,
       gridLines: null,
       showTitle: false,
@@ -121,6 +125,8 @@
       exportWidth: '',
       exportHeight: '',
       exportStylesheet: null,
+      disableChartInteraction: false,
+      disableLegendInteraction: false,
       areaOpacity: 20,
       yRound: 4,
       barWidth: 0.5,
@@ -134,7 +140,7 @@
       dataAttributes: ['type', 'rotated', 'labels', 'defaultView', 'grid', 'xLabel', 'yLabel', 'xTickRotate',
         'xTickCount', 'yTickCount', 'xTickCull', 'stacked', 'exportWidth', 'exportHeight', 'areaOpacity',
         'xTickCentered', 'barWidth', 'yRound', 'showTitle', 'title', 'hidePoints', 'pointSize',
-        'xAxisLabelPos', 'yAxisLabelPos', 'gridLines'],
+        'xAxisLabelPos', 'yAxisLabelPos', 'gridLines', 'disableChartInteraction', 'disableLegendInteraction'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',
@@ -213,6 +219,16 @@
       // Allows a column/heading to define its graph type, overriding the default.
       if ($cell.data('type') !== undefined) {
         self.settings.types[value] = $cell.data('type');
+      }
+
+      // Allows a column/heading to hide legends.
+      if ($cell.data('legend') !== undefined && $cell.data('legend') === 'hide') {
+        self.settings.disabledLegends.push(value);
+      }
+
+      // Allows a column/heading applying classes to a dataset.
+      if ($cell.data('class') !== undefined) {
+        self.settings.dataClasses[value] = $cell.data('class');
       }
 
       // Create a group of headings (used for stacking).

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -100,6 +100,9 @@
         data.columns.push(col);
       });
 
+      // Add optional classes.
+      data.classes = self.settings.dataClasses;
+
       // Add to options.
       self.options.data = data;
 
@@ -243,9 +246,34 @@
      * Parse generic chart options.
      */
     self.parseChartOptions = function () {
+      self.options.legend = {};
+
       // Add optional title.
       if (self.settings.showTitle) {
         self.options.title = {text: self.settings.title};
+      }
+
+      // Disable legend click/hover.
+      if (self.settings.disableLegendInteraction) {
+        self.options.legend.item = {
+          onclick: function () {
+            return false;
+          },
+          onmouseover: function () {
+            this.api.revert();
+            return false;
+          }
+        };
+      }
+
+      // Disable chart interaction.
+      if (self.settings.disableChartInteraction) {
+        self.options.interaction = {enabled: false};
+      }
+
+      // Hide specific dataset legends.
+      if (self.settings.disabledLegends.length > 0) {
+        self.options.legend.hide = self.settings.disabledLegends;
       }
 
       // Return self for chaining.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -18,6 +18,8 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'disable_chart_interaction' => 0,
+    'disable_legend_interaction' => 0,
     'label_settings' => array(
       'overrides' => NULL,
     ),
@@ -54,6 +56,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
     $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
+    $grid_lines = govcms_ckan_get_config_value($config, 'grid_lines/lines', array());
 
     // Attributes for the table.
     $attributes = array(
@@ -74,7 +77,9 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
       'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
-      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_get_config_value($config, 'grid_lines/lines', array())),
+      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_array_valid_rows($grid_lines, 'value')),
+      'data-disableChartInteraction' => (govcms_ckan_get_config_value($config, 'disable_chart_interaction') == 1 ? 'true' : 'false'),
+      'data-disableLegendInteraction' => (govcms_ckan_get_config_value($config, 'disable_legend_interaction') == 1 ? 'true' : 'false'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -90,6 +95,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
     $parser
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
+      ->setKeysOrder($column_overrides, 'data-weight')
       ->setHeaderSource($config['x_axis_grouping'])
       ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
@@ -118,18 +124,19 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
  * Configure form callback.
  */
 function govcms_ckan_display_bar_chart_configure($plugin, $form, &$form_state, $config) {
-  // Get default key elements.
-  $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
 
-  $config_form['rotated'] = array(
-    '#type' => 'select',
-    '#title' => t('Orientation'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
-    '#options' => array(
-      'false' => t('Vertical'),
-      'true' => t('Horizontal'),
-    ),
+  // Include default widgets.
+  $widgets = array(
+    'govcms_ckan_media_visualisation_default_key_config',
+    'govcms_ckan_media_visualisation_default_axis_config',
+    'govcms_ckan_media_visualisation_default_grid_config',
+    'govcms_ckan_media_visualisation_default_chart_config',
   );
+  $config_form = govcms_ckan_media_visualisation_include_form_widgets($form, $form_state, $config, $widgets);
+
+  // Custom settings.
+  $title = govcms_ckan_media_form_title_element(t('@title settings', array('@title' => $plugin['title'])));
+  $config_form['title_custom_settings'] = $title;
 
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
@@ -153,29 +160,6 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, &$form_state, $
     '#title' => t('Is this stacked'),
     '#default_value' => govcms_ckan_get_config_value($config, 'stacked'),
   );
-
-  $config_form['palette_override'] = array(
-    '#title' => t('Palette override'),
-    '#type' => 'textfield',
-    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
-    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
-  );
-
-  $config_form['grid'] = array(
-    '#type' => 'select',
-    '#title' => t('Enable grid'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
-    '#empty_option' => t('None'),
-    '#options' => array(
-      'x' => t('X Lines'),
-      'y' => t('Y Lines'),
-      'xy' => t('Both X and Y lines'),
-    ),
-  );
-
-  // Add axis settings.
-  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
-  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -18,6 +18,8 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'disable_chart_interaction' => 0,
+    'disable_legend_interaction' => 0,
     'area_opacity' => 20,
     'label_settings' => array(
       'overrides' => NULL,
@@ -55,6 +57,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
     $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
+    $grid_lines = govcms_ckan_get_config_value($config, 'grid_lines/lines', array());
 
     // Attributes for the table.
     $attributes = array(
@@ -75,7 +78,9 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
       'data-areaOpacity' => govcms_ckan_get_config_value($config, 'area_opacity', 20),
-      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_get_config_value($config, 'grid_lines/lines', array())),
+      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_array_valid_rows($grid_lines, 'value')),
+      'data-disableChartInteraction' => (govcms_ckan_get_config_value($config, 'disable_chart_interaction') == 1 ? 'true' : 'false'),
+      'data-disableLegendInteraction' => (govcms_ckan_get_config_value($config, 'disable_legend_interaction') == 1 ? 'true' : 'false'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -91,6 +96,7 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
     $parser
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
+      ->setKeysOrder($column_overrides, 'data-weight')
       ->setHeaderSource($config['x_axis_grouping'])
       ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
@@ -119,18 +125,19 @@ function govcms_ckan_display_line_chart_view($file, $display, $config) {
  * Configure form callback.
  */
 function govcms_ckan_display_line_chart_configure($plugin, $form, &$form_state, $config) {
-  // Get default key elements.
-  $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
 
-  $config_form['rotated'] = array(
-    '#type' => 'select',
-    '#title' => t('Orientation'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
-    '#options' => array(
-      'false' => t('Vertical'),
-      'true' => t('Horizontal'),
-    ),
+  // Include default widgets.
+  $widgets = array(
+    'govcms_ckan_media_visualisation_default_key_config',
+    'govcms_ckan_media_visualisation_default_axis_config',
+    'govcms_ckan_media_visualisation_default_grid_config',
+    'govcms_ckan_media_visualisation_default_chart_config',
   );
+  $config_form = govcms_ckan_media_visualisation_include_form_widgets($form, $form_state, $config, $widgets);
+
+  // Custom settings.
+  $title = govcms_ckan_media_form_title_element(t('@title settings', array('@title' => $plugin['title'])));
+  $config_form['title_custom_settings'] = $title;
 
   $config_form['area'] = array(
     '#type' => 'checkbox',
@@ -165,29 +172,6 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, &$form_state, 
     '#title' => t('Disable data points'),
     '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
-
-  $config_form['palette_override'] = array(
-    '#title' => t('Palette override'),
-    '#type' => 'textfield',
-    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
-    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
-  );
-
-  $config_form['grid'] = array(
-    '#type' => 'select',
-    '#title' => t('Enable grid'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
-    '#empty_option' => t('None'),
-    '#options' => array(
-      'x' => t('X Lines'),
-      'y' => t('Y Lines'),
-      'xy' => t('Both X and Y lines'),
-    ),
-  );
-
-  // Add axis settings.
-  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
-  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
@@ -17,6 +17,8 @@ $plugin = array(
     'x_label' => NULL,
     'y_label' => NULL,
     'column_overrides' => array(),
+    'disable_chart_interaction' => 0,
+    'disable_legend_interaction' => 0,
     'label_settings' => array(
       'overrides' => NULL,
     ),
@@ -53,6 +55,7 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
     $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
+    $grid_lines = govcms_ckan_get_config_value($config, 'grid_lines/lines', array());
 
     // Attributes for the table.
     $attributes = array(
@@ -72,7 +75,9 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
       'data-xTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
-      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_get_config_value($config, 'grid_lines/lines', array())),
+      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_array_valid_rows($grid_lines, 'value')),
+      'data-disableChartInteraction' => (govcms_ckan_get_config_value($config, 'disable_chart_interaction') == 1 ? 'true' : 'false'),
+      'data-disableLegendInteraction' => (govcms_ckan_get_config_value($config, 'disable_legend_interaction') == 1 ? 'true' : 'false'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -88,6 +93,7 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
     $parser
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
+      ->setKeysOrder($column_overrides, 'data-weight')
       ->setHeaderSource($config['x_axis_grouping'])
       ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
@@ -117,19 +123,19 @@ function govcms_ckan_display_scatter_plot_chart_view($file, $display, $config) {
  * Configure form callback.
  */
 function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, &$form_state, $config) {
-  // Get default key elements.
-  $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
 
-  // Point chart specific settings.
-  $config_form['rotated'] = array(
-    '#type' => 'select',
-    '#title' => t('Orientation'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
-    '#options' => array(
-      'false' => t('Vertical'),
-      'true' => t('Horizontal'),
-    ),
+  // Include default widgets.
+  $widgets = array(
+    'govcms_ckan_media_visualisation_default_key_config',
+    'govcms_ckan_media_visualisation_default_axis_config',
+    'govcms_ckan_media_visualisation_default_grid_config',
+    'govcms_ckan_media_visualisation_default_chart_config',
   );
+  $config_form = govcms_ckan_media_visualisation_include_form_widgets($form, $form_state, $config, $widgets);
+
+  // Custom settings.
+  $title = govcms_ckan_media_form_title_element(t('@title settings', array('@title' => $plugin['title'])));
+  $config_form['title_custom_settings'] = $title;
 
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
@@ -143,29 +149,6 @@ function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, &$form
     '#default_value' => govcms_ckan_get_config_value($config, 'point_size'),
     '#description' => t('Default point size is 2.5'),
   );
-
-  $config_form['palette_override'] = array(
-    '#title' => t('Palette override'),
-    '#type' => 'textfield',
-    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
-    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
-  );
-
-  $config_form['grid'] = array(
-    '#type' => 'select',
-    '#title' => t('Enable grid'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
-    '#empty_option' => t('None'),
-    '#options' => array(
-      'x' => t('X Lines'),
-      'y' => t('Y Lines'),
-      'xy' => t('Both X and Y lines'),
-    ),
-  );
-
-  // Axis settings.
-  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
-  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -19,6 +19,8 @@ $plugin = array(
     'y_label' => NULL,
     'column_overrides' => array(),
     'area_opacity' => 20,
+    'disable_chart_interaction' => 0,
+    'disable_legend_interaction' => 0,
     'label_settings' => array(
       'overrides' => NULL,
     ),
@@ -55,6 +57,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
     $keys = array_filter($config['keys']);
     $column_overrides = govcms_ckan_display_parse_column_overrides(govcms_ckan_get_config_value($config, 'column_overrides'));
     $label_replacements = govcms_ckan_string_to_array(govcms_ckan_get_config_value($config, 'label_settings/overrides'));
+    $grid_lines = govcms_ckan_get_config_value($config, 'grid_lines/lines', array());
 
     // Attributes for the table.
     $attributes = array(
@@ -75,7 +78,9 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
       'data-yTickCount' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
       'data-xTickCull' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
       'data-areaOpacity' => govcms_ckan_get_config_value($config, 'area_opacity', 20),
-      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_get_config_value($config, 'grid_lines/lines', array())),
+      'data-gridLines' => govcms_ckan_json_encode_attribute(govcms_ckan_array_valid_rows($grid_lines, 'value')),
+      'data-disableChartInteraction' => (govcms_ckan_get_config_value($config, 'disable_chart_interaction') == 1 ? 'true' : 'false'),
+      'data-disableLegendInteraction' => (govcms_ckan_get_config_value($config, 'disable_legend_interaction') == 1 ? 'true' : 'false'),
 
       // Display settings.
       'data-palette' => (!empty($config['palette_override']) ? $config['palette_override'] : $config['palette']),
@@ -91,6 +96,7 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
     $parser
       ->setKeys($keys)
       ->setLabelKey($config['labels'])
+      ->setKeysOrder($column_overrides, 'data-weight')
       ->setHeaderSource($config['x_axis_grouping'])
       ->setLabelReplacements($label_replacements)
       ->setTableAttributes($attributes)
@@ -119,18 +125,19 @@ function govcms_ckan_display_spline_chart_view($file, $display, $config) {
  * Configure form callback.
  */
 function govcms_ckan_display_spline_chart_configure($plugin, $form, &$form_state, $config) {
-  // Get default key elements.
-  $config_form = govcms_ckan_media_visualisation_default_key_config($form, $form_state, $config);
 
-  $config_form['rotated'] = array(
-    '#type' => 'select',
-    '#title' => t('Orientation'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
-    '#options' => array(
-      'false' => t('Vertical'),
-      'true' => t('Horizontal'),
-    ),
+  // Include default widgets.
+  $widgets = array(
+    'govcms_ckan_media_visualisation_default_key_config',
+    'govcms_ckan_media_visualisation_default_axis_config',
+    'govcms_ckan_media_visualisation_default_grid_config',
+    'govcms_ckan_media_visualisation_default_chart_config',
   );
+  $config_form = govcms_ckan_media_visualisation_include_form_widgets($form, $form_state, $config, $widgets);
+
+  // Custom settings.
+  $title = govcms_ckan_media_form_title_element(t('@title settings', array('@title' => $plugin['title'])));
+  $config_form['title_custom_settings'] = $title;
 
   $config_form['area'] = array(
     '#type' => 'checkbox',
@@ -165,29 +172,6 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, &$form_state
     '#title' => t('Disable data points'),
     '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
-
-  $config_form['palette_override'] = array(
-    '#title' => t('Palette override'),
-    '#type' => 'textfield',
-    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
-    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
-  );
-
-  $config_form['grid'] = array(
-    '#type' => 'select',
-    '#title' => t('Enable grid'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
-    '#empty_option' => t('None'),
-    '#options' => array(
-      'x' => t('X Lines'),
-      'y' => t('Y Lines'),
-      'xy' => t('Both X and Y lines'),
-    ),
-  );
-
-  // Add axis settings.
-  $axis_config_form = govcms_ckan_media_visualisation_default_axis_config($form, $form_state, $config);
-  $config_form = array_merge($config_form, $axis_config_form);
 
   return $config_form;
 }

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -226,6 +226,36 @@ function _govcms_ckan_media_field_widget_visualisation_options() {
  ******************************/
 
 /**
+ * A helper for visualisations to easily include required form widgets.
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state.
+ * @param array $config
+ *   Current configuration.
+ * @param array $widgets
+ *   An array of widgets to include. Eg
+ *   - govcms_ckan_media_visualisation_default_key_config
+ *   - govcms_ckan_media_visualisation_default_axis_config
+ *   - govcms_ckan_media_visualisation_default_chart_config
+ *   - govcms_ckan_media_visualisation_default_grid_config
+ *   This enables a visualisation to only include widgets it needs.
+ *
+ * @return mixed
+ *   A form array with all widgets included.
+ */
+function govcms_ckan_media_visualisation_include_form_widgets($form, &$form_state, $config, $widgets = array()) {
+  $elements = array();
+  foreach ($widgets as $callback) {
+    if (function_exists($callback)) {
+      $elements += $callback($form, $form_state, $config);
+    }
+  }
+  return $elements;
+}
+
+/**
  * This helper provides the common elements for selecting the keys.
  *
  * This is implemented by the visualisation and merged into the form structure
@@ -283,6 +313,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     // All fields.
     $options['all'][$field->id] = $field->id;
   }
+
+  $form['title_data_settings'] = govcms_ckan_media_form_title_element(t('Data settings'));
 
   // Optional filter and query parameters.
   $form['ckan_filters'] = array(
@@ -371,6 +403,9 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#description' => t('Optionally spit into multiple visualisations based on the value of this key.'),
   );
 
+  $column_override_examples = array(
+    'type|line', 'color|#000000', 'legend|hide', 'style|dashed', 'weight|20', 'class|hide-points',
+  );
   $form['column_overrides'] = array(
     '#prefix' => '<div id="' . $col_override_id . '">',
     '#suffix' => '</div>',
@@ -378,7 +413,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#collapsed' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Column overrides'),
-    '#description' => t('Optionally override a style for a specific column, add one key|value per line and separate key value with a pipe.<br />Examples: <b>type|line</b> or <b>color|#000000</b> or <b>style|dashed</b>.'),
+    '#description' => '<p>' . t('Optionally override a style for a specific column, add one key|value per line and separate key value with a pipe.<br />Examples: <strong>!examples</strong>.',
+      array('!examples' => implode('</strong> or <strong>', $column_override_examples))) . '</p>',
   );
 
   // Get the columns in use and make a text area for each to store its settings.
@@ -445,11 +481,16 @@ function govcms_ckan_media_visualisation_default_key_config_col_override_callbac
 function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state, $config = array()) {
   $element = array();
 
-  // Chart title.
-  $element['show_title'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Display chart title'),
-    '#default_value' => $config['show_title'],
+  $element['title_axis_settings'] = govcms_ckan_media_form_title_element(t('Axis settings'));
+
+  $element['rotated'] = array(
+    '#type' => 'select',
+    '#title' => t('Orientation'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
+    '#options' => array(
+      'false' => t('Vertical'),
+      'true' => t('Horizontal'),
+    ),
   );
 
   // Labels.
@@ -504,9 +545,45 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#description' => t('The number of X labels will be adjusted to <strong>less than this value</strong>.<br /><strong>NOTE: This will only work if the X axis labels are numbers</strong> as maths is used to reduce the label count.<br />Labels will be rounded to nearest whole number.'),
   );
 
+  return $element;
+}
+
+/**
+ * This helper provides the common elements for graph display grid settings.
+ *
+ * Eg: labels, tick counts, etc.
+ *
+ * @param array $form
+ *   Form array for the parent form.
+ * @param array $form_state
+ *   Current form state array from the parent form.
+ * @param array $config
+ *   The current configuration values.
+ *
+ * @return array
+ *   Form structure for new elements.
+ */
+function govcms_ckan_media_visualisation_default_grid_config($form, &$form_state, $config = array()) {
+  $element = array();
+
+  $element['title_grid_settings'] = govcms_ckan_media_form_title_element(t('Grid settings'));
+
+  $element['grid'] = array(
+    '#type' => 'select',
+    '#title' => t('Enable grid'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
+    '#empty_option' => t('None'),
+    '#options' => array(
+      'x' => t('X Lines'),
+      'y' => t('Y Lines'),
+      'xy' => t('Both X and Y lines'),
+    ),
+  );
+
   // Additional grind line configuration.
   $grid_lines_id = 'axis-lines-settings';
   $grid_line_values = govcms_ckan_get_config_value($config, 'grid_lines/lines', array());
+  $grid_line_values = govcms_ckan_array_valid_rows($grid_line_values, 'value');
   if (empty($form_state['grid_line_count'])) {
     $form_state['grid_line_count'] = count($grid_line_values) > 0 ? count($grid_line_values) : 1;
   }
@@ -620,4 +697,67 @@ function govcms_ckan_media_visualisation_default_grid_lines_config_remove_one($f
     $form_state['grid_line_count']--;
   }
   $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * This helper provides the common elements for generic chart display settings.
+ *
+ * Eg: Titles, legends, palette, etc.
+ *
+ * @param array $form
+ *   Form array for the parent form.
+ * @param array $form_state
+ *   Current form state array from the parent form.
+ * @param array $config
+ *   The current configuration values.
+ *
+ * @return array
+ *   Form structure for new elements.
+ */
+function govcms_ckan_media_visualisation_default_chart_config($form, &$form_state, $config = array()) {
+  $element = array();
+
+  $element['title_chart_settings'] = govcms_ckan_media_form_title_element(t('Chart settings'));
+
+  $element['show_title'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable chart title'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'show_title'),
+  );
+
+  $element['disable_chart_interaction'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Disable chart interaction'),
+    '#description' => t('Prevents values from showing on chart hover.'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'disable_chart_interaction'),
+  );
+
+  $element['disable_legend_interaction'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Disable legend interaction'),
+    '#description' => t('This disables click to toggle and hover effects on the legend.'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'disable_legend_interaction'),
+  );
+
+  $element['palette_override'] = array(
+    '#title' => t('Palette override'),
+    '#type' => 'textfield',
+    '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
+    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
+  );
+
+  return $element;
+}
+
+/**
+ * A helper to return a form title element (markup).
+ *
+ * @param string $title
+ *   The title to use.
+ *
+ * @return array
+ *   Markup form element.
+ */
+function govcms_ckan_media_form_title_element($title) {
+  return array('#type' => 'markup', '#markup' => '<h3 class="form-item">' . $title . '</h3>');
 }

--- a/src/GovCmsCkanDatasetParser.inc
+++ b/src/GovCmsCkanDatasetParser.inc
@@ -102,6 +102,38 @@ class GovCmsCkanDatasetParser {
   }
 
   /**
+   * Re-orders the keys as per provided order array.
+   *
+   * @param array $order
+   *   An array keyed by the key (original) name, the value for each should be
+   *   an array containing a weight key. The lower the weight the higher it
+   *   appears in the list. If no weight found, default order is used.
+   * @param string $weight_key
+   *   The key that contains the weight.
+   *
+   * @return $this
+   *   Return self for chaining.
+   */
+  public function setKeysOrder($order = array(), $weight_key = 'weight') {
+    $items = array();
+    $new_order = array();
+    // Give each key a weight either the original pos or overridden value.
+    $i = 0;
+    foreach ($this->keys as $pos => $key) {
+      $weight = isset($order[$key][$weight_key]) ? $order[$key][$weight_key] : $i;
+      $items[] = array('key' => $key, 'weight' => $weight);
+      $i++;
+    }
+    // Sort and create a new array of keys in the correct order.
+    uasort($items, array($this, 'sortWeight'));
+    foreach ($items as $item) {
+      $new_order[$item['key']] = $item['key'];
+    }
+    $this->keys = $new_order;
+    return $this;
+  }
+
+  /**
    * Define which key in $keys is the property that returns the label string.
    *
    * @param string $label_key
@@ -224,7 +256,7 @@ class GovCmsCkanDatasetParser {
   }
 
   /**
-   * Normalises attributes so all keys are lowercase.
+   * Normalises attributes so all keys are lowercase and removes empty attrs.
    *
    * @return array
    *   An array of attributes.
@@ -232,7 +264,9 @@ class GovCmsCkanDatasetParser {
   public function normaliseAttributes($attributes) {
     $attrs = array();
     foreach ($attributes as $key => $value) {
-      $attrs[strtolower($key)] = $value;
+      if ($value != '') {
+        $attrs[strtolower($key)] = $value;
+      }
     }
     return $attrs;
   }
@@ -402,6 +436,21 @@ class GovCmsCkanDatasetParser {
    */
   private function parseLabel($value) {
     return !empty($this->labelReplacements[$value]) ? $this->labelReplacements[$value] : $value;
+  }
+
+  /**
+   * Callback for uasort by weight.
+   *
+   * Exact copy of drupal_sort_weight() but included here to ensure class has no
+   * dependance on drupal.
+   */
+  private function sortWeight($a, $b) {
+    $a_weight = (is_array($a) && isset($a['weight'])) ? $a['weight'] : 0;
+    $b_weight = (is_array($b) && isset($b['weight'])) ? $b['weight'] : 0;
+    if ($a_weight == $b_weight) {
+      return 0;
+    }
+    return ($a_weight < $b_weight) ? -1 : 1;
   }
 
   /**


### PR DESCRIPTION
Hey @srowlands 

Things added to the bag of tricks, combined together gives us enough tweaking power to solve ENV-379.

Generic additions:
- Ability to toggle chart interaction (data values on hover)
- Ability to toggle legend interaction (legend click/hover)

Column override additions:
- Ability to hide a columns legend
- Ability to set weight and to override default dataset ordering
- Ability to add a class to apply to that dataset only (added OTTB class for hiding points)

Bugfixes:
- Export to PNG broke if non utf-8 chars were in the chart (eg labels) - Fixed

Cleanup/Refactor:
- Separated logical groups of default settings into callbacks so visualisations can include them as required, this also resulted in a more logical grouping of settings (with titles) Eg. Data, Axis, Grid, Chart
- Abstracted elements used in every chart into well named settings form callbacks. Eg. Grid, palette, rotation

💯 
