### PR TITLE
Admin style fixes when form viewed in ctools modal

### DIFF
--- a/modules/govcms_ckan_media/css/govcms_ckan_media.admin.css
+++ b/modules/govcms_ckan_media/css/govcms_ckan_media.admin.css
@@ -1,0 +1,19 @@
+/* Admin form specific styles for govcms_ckan_media */
+
+/* Fix for ctools modal inline form-item overrides */
+.govcms-ckan-media--settings-form .container-inline .form-item label {
+  width: auto;
+  float: none;
+}
+.govcms-ckan-media--settings-form .container-inline .form-item {
+  display: inline-block;
+  margin: 0 0.5em 0.5em 0;
+  white-space: nowrap;
+}
+
+/* Section title readability improvement */
+.govcms-ckan-media--settings-title {
+  margin: 1.2em 0;
+  padding-bottom: 0.5em;
+  border-bottom: 2px solid rgba(0,0,0,0.1);
+}

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -91,6 +91,16 @@ function govcms_ckan_media_field_load($entity_type, $entities, $field, $instance
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function govcms_ckan_media_preprocess_html(&$variables) {
+  // Add the admin stylesheet if on an admin page.
+  if (path_is_admin(current_path())) {
+    drupal_add_css(drupal_get_path('module', 'govcms_ckan_media') . '/css/govcms_ckan_media.admin.css');
+  }
+}
+
+/**
  * Implements hook_field_widget_form().
  */
 function govcms_ckan_media_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {
@@ -142,7 +152,10 @@ function govcms_ckan_media_field_widget_form(&$form, &$form_state, $field, $inst
   // The wrapper element for visualisation configuration.
   $widget['visualisation_config'] = array(
     '#type' => 'container',
-    '#attributes' => array('id' => $vis_wrapper_id),
+    '#attributes' => array(
+      'id' => $vis_wrapper_id,
+      'class' => array('govcms-ckan-media--settings-form'),
+    ),
   );
 
   // If config says there is a configuration, load the form from the plugin.
@@ -759,5 +772,5 @@ function govcms_ckan_media_visualisation_default_chart_config($form, &$form_stat
  *   Markup form element.
  */
 function govcms_ckan_media_form_title_element($title) {
-  return array('#type' => 'markup', '#markup' => '<h3 class="form-item">' . $title . '</h3>');
+  return array('#type' => 'markup', '#markup' => '<h3 class="govcms-ckan-media--settings-title">' . $title . '</h3>');
 }


### PR DESCRIPTION
Hey @srowlands,

Last fix for the sprint :) ctools modal styles broke my lovely inline fields, this adds an admin stylesheet and fixes that + make the titles look a bit better.
