### PR TITLE
Added improved help for admins

### DIFF
--- a/css/govcms-ckan.help.css
+++ b/css/govcms-ckan.help.css
@@ -1,0 +1,43 @@
+body {
+    font: normal 12px "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+    padding: 10px;
+    margin: 0;
+}
+
+h2, h3 {
+    border-bottom: 1px solid #ddd;
+    margin: 0.5em 0;
+    padding-bottom: 0.3em;
+}
+
+h3 {
+    border-bottom-style: dotted;
+}
+
+h4 {
+    border-left: 2px solid #ddd;
+    padding-left: 0.3em;
+}
+
+table {
+    width: 100%;
+    font-size: 12px;
+}
+
+th {
+    background: #eee;
+}
+
+td, th {
+    padding: 5px;
+    border: 1px solid #ddd;
+    text-align: left;
+}
+
+pre {
+    border: 1px solid #ccc;
+    background: #f6f6f6;
+    padding: 10px;
+    margin: 0.5em 0 1em;
+    border-radius: 3px;
+}

--- a/govcms_ckan.help.inc
+++ b/govcms_ckan.help.inc
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Help functionality.
+ */
+
+/**
+ * Help page callback for govCMS CKAN modules.
+ *
+ * @param string $module
+ *   Module providing the help files.
+ * @param string $page
+ *   The key for the help file.
+ */
+function govcms_ckan_help_callback($module, $page) {
+  $page = drupal_get_path('module', $module) . '/help/' . $page . '.html';
+  $page_content = '';
+  if (file_exists($page)) {
+    $page_content = file_get_contents($page);
+  }
+  print theme('govcms_ckan_help_page', array('page_content' => $page_content));
+  exit;
+}

--- a/govcms_ckan.module
+++ b/govcms_ckan.module
@@ -11,6 +11,11 @@
 define('GOVCMS_CKAN_CONFIG_PATH', 'admin/config/services/govcms-ckan');
 
 /**
+ * Base path to the help pages.
+ */
+define('GOVCMS_CKAN_HELP_PATH', 'govcms-ckan/help');
+
+/**
  * Limit of records retrieved via the API. CKAN default is 100.
  *
  * TODO: Move this to a configuration (somewhere). For now, we really want all
@@ -31,6 +36,7 @@ function govcms_ckan_ctools_plugin_directory($module, $plugin) {
  * Implements hook_menu().
  */
 function govcms_ckan_menu() {
+
   $items[GOVCMS_CKAN_CONFIG_PATH] = array(
     'title' => 'govCMS CKAN',
     'description' => 'Settings for govCMS CKAN',
@@ -39,7 +45,35 @@ function govcms_ckan_menu() {
     'access arguments' => array('administer govcms ckan'),
     'file' => 'govcms_ckan.admin.inc',
   );
+
+  // Help functionality modeled on drupal.org/project/advanced_help which is
+  // currently not available in govCMS. If this changes in the future help files
+  // should be compatible and we just change the implementation slightly.
+  $items[GOVCMS_CKAN_HELP_PATH . '/%/%'] = array(
+    'title' => 'govCMS CKAN Help',
+    'page callback' => 'govcms_ckan_help_callback',
+    'page arguments' => array(2, 3),
+    'access arguments' => array('view govcms ckan help'),
+    'file' => 'govcms_ckan.help.inc',
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
+}
+
+/**
+ * Implements hook_theme().
+ */
+function govcms_ckan_theme($existing, $type, $theme, $path) {
+  return array(
+    'govcms_ckan_help_page' => array(
+      'variables' => array(
+        'page_content' => NULL,
+        'css' => $path . '/css/govcms-ckan.help.css',
+      ),
+      'template' => 'theme/templates/govcms-ckan-help-page',
+    ),
+  );
 }
 
 /**
@@ -50,6 +84,10 @@ function govcms_ckan_permission() {
     'administer govcms ckan' => array(
       'title' => t('Administer govCMS CKAN'),
       'description' => t('Allows the user to access the govCMS CKAN admin page.'),
+    ),
+    'view govcms ckan help' => array(
+      'title' => t('View govCMS CKAN help'),
+      'description' => t('Allows the user to view govCMS CKAN help topics.'),
     ),
   );
 }
@@ -337,4 +375,38 @@ function govcms_ckan_array_valid_rows($rows, $not_empty_key = 'value') {
     }
   }
   return $array;
+}
+
+/**
+ * Returns a link that opens a popup to the given help page.
+ *
+ * This mimics the way Views uses Advanced Help, using onclick instead of
+ * external js to reduce load when not in use.
+ *
+ * @param string $module
+ *   The module implementing the help.
+ * @param string $key
+ *   The key for the help file.
+ * @param string $title
+ *   The title to use for the link.
+ *
+ * @return string
+ *   A link ready to be rendered.
+ */
+function govcms_ckan_help_link($module, $key, $title = 'More help') {
+  if (!user_access('view govcms ckan help')) {
+    return NULL;
+  }
+  return l(
+    '<span>' . $title . '</span>',
+    GOVCMS_CKAN_HELP_PATH . '/' . $module . '/' . $key,
+    array(
+      'html' => TRUE,
+      'attributes' => array(
+        'onclick' => "var w=window.open(this.href, 'advanced_help_window', 'width=500,height=500,scrollbars,resizable'); w.focus(); return false;",
+        'title' => $title,
+        'class' => array('govcms-ckan-help-link'),
+      ),
+    )
+  );
 }

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -153,23 +153,28 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, &$form_state, $
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
+    '#description' => t('Show the data values above the bars.'),
     '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 
   $config_form['bar_width'] = array(
     '#type' => 'select',
     '#title' => t('Bar width'),
-    '#default_value' => govcms_ckan_get_config_value($config, 'bar_width'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'bar_width', '0.5'),
+    '#description' => t('Override the default width of the bars.'),
     '#options' => array(
-      '0.5' => t('Standard'),
+      '0.2' => t('Extra thin'),
       '0.3' => t('Thin'),
+      '0.5' => t('Standard'),
       '0.75' => t('Thick'),
+      '0.9' => t('Extra thick'),
     ),
   );
 
   $config_form['stacked'] = array(
     '#type' => 'checkbox',
     '#title' => t('Is this stacked'),
+    '#description' => t('Stacking a bar chart will display the bars on top of each other rather than side by side.'),
     '#default_value' => govcms_ckan_get_config_value($config, 'stacked'),
   );
 

--- a/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/line_chart.inc
@@ -155,6 +155,7 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, &$form_state, 
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area'),
+    '#description' => t('Enabling area fills in the area between the X axis and the line.'),
   );
 
   $area_opacity_options = array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
@@ -163,6 +164,7 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, &$form_state, 
     '#title' => t('Area Opacity'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area_opacity'),
     '#options' => array_combine($area_opacity_options, $area_opacity_options),
+    '#description' => t('Define the opacity of the area. This does not affect the line.'),
     '#states' => array(
       'visible' => array(
         // This field is deeply nested so resorting to a fairly ugly selector
@@ -176,12 +178,14 @@ function govcms_ckan_display_line_chart_configure($plugin, $form, &$form_state, 
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
+    '#description' => t('Display the data values above each point'),
     '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 
   $config_form['hide_points'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable data points'),
+    '#description' => t('Remove the dots from the lines'),
     '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
 

--- a/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/scatter_plot_chart.inc
@@ -152,6 +152,7 @@ function govcms_ckan_display_scatter_plot_chart_configure($plugin, $form, &$form
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
+    '#description' => t('Display the data values above each point'),
     '#default_value' => govcms_ckan_get_config_value($config, 'show_labels'),
   );
 

--- a/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/spline_chart.inc
@@ -155,6 +155,7 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, &$form_state
     '#type' => 'checkbox',
     '#title' => t('Enable area'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area'),
+    '#description' => t('Enabling area fills in the area between the X axis and the line.'),
   );
 
   $area_opacity_options = array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100);
@@ -163,6 +164,7 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, &$form_state
     '#title' => t('Area Opacity'),
     '#default_value' => govcms_ckan_get_config_value($config, 'area_opacity'),
     '#options' => array_combine($area_opacity_options, $area_opacity_options),
+    '#description' => t('Define the opacity of the area. This does not affect the line.'),
     '#states' => array(
       'visible' => array(
         // This field is deeply nested so resorting to a fairly ugly selector
@@ -176,12 +178,14 @@ function govcms_ckan_display_spline_chart_configure($plugin, $form, &$form_state
   $config_form['show_labels'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable data labels'),
+    '#description' => t('Display the data values above each point'),
     '#default_value' => $config['show_labels'],
   );
 
   $config_form['hide_points'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable data points'),
+    '#description' => t('Remove the dots from the lines'),
     '#default_value' => govcms_ckan_get_config_value($config, 'hide_points'),
   );
 

--- a/modules/govcms_ckan_media/govcms_ckan_media.module
+++ b/modules/govcms_ckan_media/govcms_ckan_media.module
@@ -92,3 +92,4 @@ function govcms_ckan_media_file_load($files) {
     }
   }
 }
+

--- a/modules/govcms_ckan_media/help/.htaccess
+++ b/modules/govcms_ckan_media/help/.htaccess
@@ -1,0 +1,4 @@
+<Files *\.html>
+Order Allow,Deny
+Deny from all
+</Files>

--- a/modules/govcms_ckan_media/help/ckan-filters.html
+++ b/modules/govcms_ckan_media/help/ckan-filters.html
@@ -1,0 +1,16 @@
+<h2>CKAN Filters</h2>
+
+<p>Filters can be used to refine/reduce the records returned from the CKAN datasource.</p>
+
+<h3>Full text query</h3>
+
+<p>This limits the results to records that contain a certain keyword or value.</p>
+
+<h3>Filters</h3>
+
+<p>This limits the results to records that match certain conditions. Eg. {"year":"2016"}.
+Format should be JSON and multiple filters can be applied at once.</p>
+
+<h3>Caution</h3>
+
+<p>As results get heavily cached, you may need to clear caches for these filters to take effect.</p>

--- a/modules/govcms_ckan_media/help/column-overrides.html
+++ b/modules/govcms_ckan_media/help/column-overrides.html
@@ -1,0 +1,53 @@
+<h2>Column/Group overrides</h2>
+
+<p>Column overrides allow you to change the style of a specific data column group. This can be useful for combining
+    different graph styles eg. lines and bars, overriding a colour, changing the order or applying a class so further
+    styling options can be defined in css.</p>
+
+<p>There is a text area for each column and you can add multiple settings per column. Add each setting on a new
+    line and separate setting name and value with a pipe (|). Eg.</p>
+
+<pre>
+type|line
+color|#cccccc
+weight|20
+legend|hide
+</pre>
+
+<h3>Available overrides</h3>
+
+<h4>type</h4>
+
+<p>Eg. If your graph is bar chart, you could use this to set one of the columns to be a line for something
+    like an average, or representing data that is slightly different than the rest.</p>
+
+<p><strong>Available options:</strong> line, spline, bar, area, area-spline or scatter</p>
+
+<h4>color</h4>
+
+<p>Override the colour on a specific column. Use a <a href="http://www.color-hex.com/" target="_blank">hex value</a>.
+    Eg. #000000 = black.</p>
+
+<h4>legend</h4>
+
+<p>Hide the legend for a specific column. This only has one option <em>hide</em>.</p>
+
+<h4>weight</h4>
+
+<p>Weighting (ordering) allows you to change the position of column/groups without having to update the
+    source dataset. Heaver items sink to the end of lists, lighter items float to the top.</p>
+
+<p>If you wanted an column to appear first, you could set a really low weight of <strong>-50</strong>.
+    Alternatively if you wanted a column to appear last you could set a high weight of <strong>50</strong>.
+    Any positive or negative integer is valid.</p>
+
+<h4>style</h4>
+
+<p>This currently only applies to line graphs and it allows you to set the line to be <strong>dashed</strong>.</p>
+
+<h4>class</h4>
+
+<p>Adding a css class to a column allows additional custom styling. Currently there is one 'out of the box' style
+available <strong>hide-points</strong> that hide the points for a specific column.</p>
+
+<p>You can add any classes you like and then define those styles is your custom css.</p>

--- a/modules/govcms_ckan_media/help/grid-lines.html
+++ b/modules/govcms_ckan_media/help/grid-lines.html
@@ -1,0 +1,28 @@
+<h2>Grid/Trend lines</h2>
+
+<p>Add additional grid lines to the chart either on the X or Y Axis. You can add as many additional lines as you
+    like.</p>
+
+<p>Additional grid lines can have a label and are useful for such things as trend lines or intersects.</p>
+
+<h3>For each grid line</h3>
+
+<h4>Axis</h4>
+
+<p>Y axis will add a horizontal line at the value defined. X axis will add a vertical line.</p>
+
+<h4>Value</h4>
+
+<p>This defines where the line will be added. The value must be within the dataset.</p>
+
+<h4>Label</h4>
+
+<p>Add an optional label to identify what the line represents. Eg average, min or max.</p>
+
+<h4>Label position</h4>
+
+<p>Define where the label appears on the line. Start, middle or end. On a X line start is the bottom, end is the top.</p>
+
+<h3>Adding and removing lines</h3>
+
+<p>Clicking 'Add line' will add a new empty line. Clicking 'Remove line' will remove the last line in the list.</p>

--- a/modules/govcms_ckan_media/help/keys.html
+++ b/modules/govcms_ckan_media/help/keys.html
@@ -1,0 +1,44 @@
+<h2>Keys</h2>
+
+<p>This is the data that gets included in the visualisation. What data to include in the visualisation.</p>
+
+<p>If X axis grouping is "Group by keys" these values will form the data groups lines/bars/legend, if
+    grouping is "group by label values" these values will be values on the X axis.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p>The available keys would be <strong>Size, Red, Green</strong> and <strong>Blue</strong> and using the keys selection, you
+    could limit it to only show <strong>Green</strong> and <strong>Blue</strong> data in the visualisation.</p>
+
+<h3>Caution</h3>
+
+<p>Do not include the key used in "Label key" as this will create a duplicate column and break graph.</p>

--- a/modules/govcms_ckan_media/help/label-key.html
+++ b/modules/govcms_ckan_media/help/label-key.html
@@ -1,0 +1,42 @@
+<h2>Label Key</h2>
+
+<p>What key contains the labels. The value of each label key will be the X tick values if group by keys
+or the legend if group by labels.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p>The label key would be <strong>Size</strong></p>
+
+<h3>Caution</h3>
+
+<p>Ensure the label key is not also selected in "Keys" as it will cause duplicate columns and
+break some visualisations.</p>

--- a/modules/govcms_ckan_media/help/label-overrides.html
+++ b/modules/govcms_ckan_media/help/label-overrides.html
@@ -1,0 +1,23 @@
+<h2>Label overrides</h2>
+
+<p>The labels in the dataset may not represent what you want to display on the site. This is most often due
+  to CKAN not allowing certain characters eg spaces or symbols.</p>
+
+<p>Label overrides allow you to do label replacements so when a label is displayed in a visualisation you can
+    improve the presentation or add additional information.</p>
+
+<p>Symbols may be used in replacements. Html code is not supported.</p>
+
+<p>Add one label override per line and separate original label and new label with a pipe (|). Eg.</p>
+
+<pre>
+MyOriginalLabel1|My nicely formatted label
+MyOtherOriginalLabel|My Awesome label
+</pre>
+
+<p>Label replacements apply to both column groups (the legend) and X axis tick values. They do <u>not</u> apply to Y
+   axis values.</p>
+
+<h3>Caution</h3>
+
+<p>All label values must be unique.</p>

--- a/modules/govcms_ckan_media/help/split.html
+++ b/modules/govcms_ckan_media/help/split.html
@@ -1,0 +1,112 @@
+<h2>Split field</h2>
+
+<p>Optionally spit into multiple visualisations based on the value of this key.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2010</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2015</td>
+        <td>12</td>
+        <td>17</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2010</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2015</td>
+        <td>32</td>
+        <td>37</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2010</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2015</td>
+        <td>62</td>
+        <td>72</td>
+    </tr>
+</table>
+
+<p>If you split on the <strong>Year</strong> field, you would get 2 graphs/tables that look like this:</p>
+
+<h4>2010</h4>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2010</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2010</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2010</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<h4>2015</h4>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2015</td>
+        <td>12</td>
+        <td>17</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2015</td>
+        <td>32</td>
+        <td>37</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2015</td>
+        <td>62</td>
+        <td>72</td>
+    </tr>
+</table>

--- a/modules/govcms_ckan_media/help/x-axis-grouping.html
+++ b/modules/govcms_ckan_media/help/x-axis-grouping.html
@@ -1,0 +1,67 @@
+<h2>X Axis Grouping</h2>
+
+<p>X Grouping allows you to flip how the data is displayed. The default "Group by Keys" will render the table
+matching the original source and in a graph the Keys will form the legend. If "Group by Labels" is used, the
+keys and labels gets swapped and in a graph the labels will form the legend.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p><strong>Group by keys</strong> would result in the same table being outputted.</p>
+
+<p>If you were to use <strong>Group by labels</strong> the rendered table would look like this:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Small</th>
+        <th>Medium</th>
+        <th>Large</th>
+    </tr>
+    <tr>
+        <th>Red</th>
+        <td>5</td>
+        <td>25</td>
+        <td>50</td>
+    </tr>
+    <tr>
+        <th>Green</th>
+        <td>10</td>
+        <td>30</td>
+        <td>60</td>
+    </tr>
+    <tr>
+        <th>Blue</th>
+        <td>15</td>
+        <td>35</td>
+        <td>70</td>
+    </tr>
+</table>

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -382,6 +382,7 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
       array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'keys'))),
   );
 
+  $col_override_id = 'col-override-settings';
   $form['labels'] = array(
     '#type' => 'select',
     '#title' => t('Label key'),
@@ -395,7 +396,6 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     ),
   );
 
-  $col_override_id = 'col-override-settings';
   $x_axis_grouping = isset($config['x_axis_grouping']) ? $config['x_axis_grouping'] : 'keys';
   $form['x_axis_grouping'] = array(
     '#type' => 'select',

--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -143,6 +143,7 @@ function govcms_ckan_media_field_widget_form(&$form, &$form_state, $field, $inst
     '#default_value' => isset($config['visualisation']) ? $config['visualisation'] : NULL,
     '#required' => ($form_state['build_info']['form_id'] != 'field_ui_field_edit_form'),
     '#options' => _govcms_ckan_media_field_widget_visualisation_options(),
+    '#description' => t('How the data from this CKAN dataset will be presented when rendered on the page.'),
     '#ajax' => array(
       'callback' => 'govcms_ckan_media_field_widget_visualisation_form',
       'wrapper' => $vis_wrapper_id,
@@ -335,6 +336,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#title' => t('CKAN data filters'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
+    '#description' => '<p>' . t('Filters can be used to refine/reduce the records returned from the CKAN datasource. !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'ckan-filters'))) . '</p>',
   );
 
   // Default values for query string.
@@ -375,7 +378,21 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#default_value' => $config['keys'],
     '#multiple' => TRUE,
     '#required' => TRUE,
-    '#description' => t('What data to display in the visualisation. Do not include the key used in "Label key" below'),
+    '#description' => t('What data to include in the visualisation. If X axis grouping is "Group by keys" these values will form the data groups lines/bars/legend, if grouping is "group by label values" these values will be values on the X axis. <strong>Do not include the key used in "Label key" below</strong>. !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'keys'))),
+  );
+
+  $form['labels'] = array(
+    '#type' => 'select',
+    '#title' => t('Label key'),
+    '#options' => $options['all'],
+    '#default_value' => $config['labels'],
+    '#description' => t('What key contains the labels. Ensure this key is not selected in "Keys" above. !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'label-key'))),
+    '#ajax' => array(
+      'callback' => 'govcms_ckan_media_visualisation_default_key_config_col_override_callback',
+      'wrapper' => $col_override_id,
+    ),
   );
 
   $col_override_id = 'col-override-settings';
@@ -388,19 +405,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
       'values' => t('Group by label values'),
     ),
     '#default_value' => $x_axis_grouping,
-    '#description' => t('Will the x axis be keys or values of the label key.'),
-    '#ajax' => array(
-      'callback' => 'govcms_ckan_media_visualisation_default_key_config_col_override_callback',
-      'wrapper' => $col_override_id,
-    ),
-  );
-
-  $form['labels'] = array(
-    '#type' => 'select',
-    '#title' => t('Label key'),
-    '#options' => $options['all'],
-    '#default_value' => $config['labels'],
-    '#description' => t('What key contains the labels. Ensure this key is not selected in "Keys" above.'),
+    '#description' => t('Will the X axis use the <em>keys</em> or the <em>label key value</em> as tick values. Changing this swaps what is displayed on the X axis (or table header if viewed as a table). !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'x-axis-grouping'))),
     '#ajax' => array(
       'callback' => 'govcms_ckan_media_visualisation_default_key_config_col_override_callback',
       'wrapper' => $col_override_id,
@@ -413,7 +419,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#options' => $options['all'],
     '#default_value' => $config['split'],
     '#empty_option' => t('None'),
-    '#description' => t('Optionally spit into multiple visualisations based on the value of this key.'),
+    '#description' => t('Optionally spit into multiple visualisations based on the value of this key. Eg. a column of the data might contain the year, with this you could split the visualisations into one per year. !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'split'))),
   );
 
   $column_override_examples = array(
@@ -425,9 +432,12 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#type' => 'fieldset',
-    '#title' => t('Column overrides'),
-    '#description' => '<p>' . t('Optionally override a style for a specific column, add one key|value per line and separate key value with a pipe.<br />Examples: <strong>!examples</strong>.',
-      array('!examples' => implode('</strong> or <strong>', $column_override_examples))) . '</p>',
+    '#title' => t('Column/Group overrides'),
+    '#description' => '<p>' . t('Optionally override a style for a specific column, add one key|value per line and separate key value with a pipe. !help.<br />Examples: <strong>!examples</strong>.',
+      array(
+        '!examples' => implode('</strong> or <strong>', $column_override_examples),
+        '!help' => govcms_ckan_help_link('govcms_ckan_media', 'column-overrides'),
+      )) . '</p>',
   );
 
   // Get the columns in use and make a text area for each to store its settings.
@@ -453,7 +463,8 @@ function govcms_ckan_media_visualisation_default_key_config($form, &$form_state,
     '#rows' => 2,
     '#title' => t('Label overrides'),
     '#default_value' => isset($config['label_settings']['overrides']) ? $config['label_settings']['overrides'] : NULL,
-    '#description' => t('Optionally override one or more labels. Add one original_label|new_label per line and separate with a pipe. This will apply to X axis labels and legend labels.'),
+    '#description' => t('Optionally override one or more labels. Add one original_label|new_label per line and separate with a pipe. This will apply to X axis labels and legend labels. !help.',
+      array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'label-overrides'))),
   );
 
   // This indicates to future parsers that these elements have been included.
@@ -500,6 +511,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'select',
     '#title' => t('Orientation'),
     '#default_value' => govcms_ckan_get_config_value($config, 'rotated'),
+    '#description' => t('Default orientation is vertical, changing to horizontal will rotate the graph 90deg clockwise with the Y axis at the bottom and X axis on the left.'),
     '#options' => array(
       'false' => t('Vertical'),
       'true' => t('Horizontal'),
@@ -511,11 +523,13 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'textfield',
     '#title' => t('X axis label'),
     '#default_value' => govcms_ckan_get_config_value($config, 'x_label'),
+    '#description' => t('Add a label to the Y axis to describe what the data values relate to. Eg Height (m) or Weight (kg).'),
   );
   $element['y_label'] = array(
     '#type' => 'textfield',
     '#title' => t('Y axis label'),
     '#default_value' => govcms_ckan_get_config_value($config, 'y_label'),
+    '#description' => t('Add a label to the X axis to describe what the values realte to. Eg Year or Category.'),
   );
 
   // Advanced settings.
@@ -534,7 +548,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#title' => t('X labels vertical'),
     '#type' => 'checkbox',
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_rotate'),
-    '#description' => t('Check to rotate the X axis labels 90 degrees.'),
+    '#description' => t('Check to rotate the X axis labels 90 degrees. This is useful when there is not enough space for the labels to display horizontally.'),
   );
 
   $element['axis_settings']['x_tick_count'] = array(
@@ -542,30 +556,30 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'textfield',
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_count'),
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The number of ticks on the X axis.'),
+    '#description' => t('Limit the number of ticks on the X axis. This only relates to the number of ticks on the X axis and not the values.'),
   );
 
   // Limit label count.
   $element['axis_settings']['x_tick_cull'] = array(
-    '#title' => t('Maximum X label count'),
+    '#title' => t('X Label count (max)'),
     '#type' => 'textfield',
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_cull'),
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The number of X labels will be adjusted to <strong>less than this value</strong>.<br /><strong>NOTE: This will only work if the X axis labels are numbers</strong> as maths is used to reduce the label count.<br />Labels will be rounded to nearest whole number.'),
+    '#description' => t('The number of X ticks and labels will be adjusted to <strong>less than this value</strong>. Labels will be rounded to nearest whole number.<br /><strong>NOTE: This will only work if the X axis labels are numbers</strong> as maths is used to reduce the label count.'),
   );
 
   $element['axis_settings']['x_tick_values'] = array(
     '#type' => 'textfield',
     '#title' => t('X Tick Values'),
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_values'),
-    '#description' => t('Override X axis tick values. Separate values with a comma, values should be numeric and within the range of the dataset.'),
+    '#description' => t('Override X axis tick values. Separate values with a comma, <strong>only numeric values supported</strong> and they should be within the range of the dataset.<br><strong>NOTE: If defining values here do not use X tick count or X label count.</strong>'),
   );
 
   $element['axis_settings']['x_tick_value_format'] = array(
     '#type' => 'select',
     '#title' => t('X Tick Value Number Format'),
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/x_tick_value_format'),
-    '#description' => t('How is the Y axis values are formatted. Only works if X values are numeric.'),
+    '#description' => t('How are the Y axis values are formatted. Only works if X values are numeric.'),
     '#options' => array(
       '' => t('None'),
       ' ' => t('Space separated Eg. 10 000'),
@@ -580,7 +594,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'textfield',
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_count'),
     '#element_validate' => array('element_validate_integer'),
-    '#description' => t('The number of ticks on the Y axis.'),
+    '#description' => t('Limit the number of ticks on the Y axis.'),
   );
 
   $element['axis_settings']['y_tick_values'] = array(
@@ -594,7 +608,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'select',
     '#title' => t('Y Tick Value Number Format'),
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/y_tick_value_format'),
-    '#description' => t('How is the Y axis values are formatted.'),
+    '#description' => t('How are the Y axis values are formatted.'),
     '#options' => array(
       '' => t('None'),
       ' ' => t('Space separated Eg. 10 000'),
@@ -609,6 +623,7 @@ function govcms_ckan_media_visualisation_default_axis_config($form, &$form_state
     '#type' => 'select',
     '#title' => t('Tick visibility'),
     '#default_value' => govcms_ckan_get_config_value($config, 'axis_settings/tick_visibility', 'show'),
+    '#description' => t('Applies to the axis ticks only and not the tick labels.'),
     '#options' => array(
       'show' => t('Show all ticks'),
       'hide-x' => t('Hide X ticks'),
@@ -645,6 +660,7 @@ function govcms_ckan_media_visualisation_default_grid_config($form, &$form_state
     '#title' => t('Enable grid'),
     '#default_value' => govcms_ckan_get_config_value($config, 'grid'),
     '#empty_option' => t('None'),
+    '#description' => t('Optionally add grid lines to a chart.'),
     '#options' => array(
       'x' => t('X Lines'),
       'y' => t('Y Lines'),
@@ -665,7 +681,8 @@ function govcms_ckan_media_visualisation_default_grid_config($form, &$form_state
     '#collapsed' => ($form_state['grid_line_count'] < 2 && empty($grid_line_values)),
     '#type' => 'fieldset',
     '#title' => t('Additional Grid / Trend Lines'),
-    '#description' => t('This allows you to draw additional grid lines on the chart. Eg Trend lines or intersects.'),
+    '#description' => '<p>' . t('This allows you to draw additional grid lines on the chart. Eg Trend lines or intersects. !help.',
+        array('!help' => govcms_ckan_help_link('govcms_ckan_media', 'grid-lines'))) . '</p>',
     '#prefix' => '<div id="' . $grid_lines_id . '">',
     '#suffix' => '</div>',
     'lines' => array(
@@ -794,6 +811,7 @@ function govcms_ckan_media_visualisation_default_chart_config($form, &$form_stat
   $element['show_title'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable chart title'),
+    '#description' => t('Render the title as part of the chart, this ensures it is present when exported.  The title used will be the file name above.'),
     '#default_value' => govcms_ckan_get_config_value($config, 'show_title'),
   );
 
@@ -807,7 +825,7 @@ function govcms_ckan_media_visualisation_default_chart_config($form, &$form_stat
   $element['disable_legend_interaction'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable legend interaction'),
-    '#description' => t('This disables click to toggle and hover effects on the legend.'),
+    '#description' => t('This disables click to toggle and hover effects on the legend. Default legend hover will focus on that column/group, default click toggles visibility of that column/group.'),
     '#default_value' => govcms_ckan_get_config_value($config, 'disable_legend_interaction'),
   );
 
@@ -815,14 +833,14 @@ function govcms_ckan_media_visualisation_default_chart_config($form, &$form_stat
     '#title' => t('Palette override'),
     '#type' => 'textfield',
     '#default_value' => govcms_ckan_get_config_value($config, 'palette_override'),
-    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied.'),
+    '#description' => t('Palette is a comma separated list of hex values. If not set, default palette is applied. If more columns exist than are defined in the palette it will loop back though the palette resulting in duplicate colours used.'),
   );
 
   // Chart padding.
   $element['chart_padding'] = array(
     '#type' => 'fieldset',
     '#title' => t('Chart padding'),
-    '#description' => t('Add additional padding to the side(s) of the chart. This can potentially break charts so use with care.'),
+    '#description' => '<p>' . t('Add additional padding to the outer edges of the chart. This can potentially break charts so use with care.') . '</p>',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#tree' => TRUE,

--- a/theme/templates/govcms-ckan-help-page.tpl.php
+++ b/theme/templates/govcms-ckan-help-page.tpl.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * Template for help page.
+ */
+?>
+<html>
+  <head>
+    <title>govCMS CKAN Help</title>
+    <link rel="stylesheet" type="text/css" href="<?php print url($css); ?>">
+  </head>
+  <body class="govcms-ckan-help">
+    <?php print $page_content; ?>
+  </body>
+</html>


### PR DESCRIPTION
Hi @srowlands 

ENV-436 - improve documentation.

I have added a mini version of advanced help and modeled on how they do things (eg. help file format & locations). If one day we get advanced help in govcms then should be an easy swap over. At this stage it just provides nice framework and little popups with verbose help information. 

Plan on improving the help files over time with example images and better examples.

Have also improved and added descriptions to every field.
