### PR TITLE
Added ability to manually set the width of bars in a bar chart

### DIFF
--- a/modules/govcms_ckan_display/js/jquery.table_charts.js
+++ b/modules/govcms_ckan_display/js/jquery.table_charts.js
@@ -39,10 +39,12 @@
    * -- data-numberFormatMinLength: Formatting of tick values only applies on numbers with a length gte to this.
    * -- data-xTickCull: The max count of labels on the X axis
    * -- data-xTickCentered: Are the x ticks centered above labels.
-   * -- data-tickVisibility: Determins tick visibiliy. Options: show, hide-x, hide-y, hide-xy.
+   * -- data-tickVisibility: Determines tick visibility. Options: show, hide-x, hide-y, hide-xy.
    * -- data-yRound: The maximum amount of decimal places to allow in the Y axis ticks
    * -- data-disableChartInteraction: Disable hover values on the chart. Default false.
    * -- data-disableLegendInteraction: Prevent hover/click defaults on legend. Default false
+   * -- data-barWidth: Set the ratio for bar widths. If set to manual it will use barWidthOverride value.
+   * -- data-barWidthOverride: Set the bar width (without a ratio), Requires barWidth to be 'manual'
    * -- data-chartPadding: Additional padding on edges of the chart. Expects object with top, right, bottom, left.
    * -- data-exportWidth: The width of the exported png. @see chartExport()
    * -- data-exportHeight: The height of the exported png. @see chartExport()
@@ -143,6 +145,7 @@
       areaOpacity: 20,
       yRound: 4,
       barWidth: 0.5,
+      barWidthOverride: 'auto',
       // The data for the chart.
       columns: [],
       data: {},
@@ -154,7 +157,8 @@
         'xTickCount', 'yTickCount', 'yTickValues', 'xTickValues', 'yTickValueFormat', 'xTickValueFormat', 'xTickCull',
         'stacked', 'exportWidth', 'exportHeight', 'areaOpacity', 'xTickCentered', 'barWidth', 'yRound', 'showTitle',
         'title', 'hidePoints', 'pointSize', 'xAxisLabelPos', 'yAxisLabelPos', 'gridLines', 'disableChartInteraction',
-        'yTickValueRound', 'disableLegendInteraction', 'numberFormatMinLength', 'tickVisibility', 'chartPadding'],
+        'yTickValueRound', 'disableLegendInteraction', 'numberFormatMinLength', 'tickVisibility', 'chartPadding',
+        'barWidthOverride'],
       // Chart views determine what is displaying chart vs table.
       chartViewName: 'chart',
       tableViewName: 'table',

--- a/modules/govcms_ckan_display/js/table_charts.c3js.js
+++ b/modules/govcms_ckan_display/js/table_charts.c3js.js
@@ -260,8 +260,13 @@
      */
     self.parseBarOptions = function () {
       if (self.settings.type === 'bar') {
-        // Provide a width ratio for bars.
-        self.options.bar = {width: {ratio: self.settings.barWidth}};
+        if (self.settings.barWidth === 'manual') {
+          // Define the width of the bar manually (not using a ratio).
+          self.options.bar = {width: self.settings.barWidthOverride};
+        } else {
+          // Provide a width ratio for bars.
+          self.options.bar = {width: {ratio: self.settings.barWidth}};
+        }
       }
 
       // Return self for chaining.

--- a/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
+++ b/modules/govcms_ckan_display/plugins/visualisation/bar_chart.inc
@@ -71,6 +71,7 @@ function govcms_ckan_display_bar_chart_view($file, $display, $config) {
 
       // Entity settings.
       'data-barWidth' => govcms_ckan_get_config_value($config, 'bar_width'),
+      'data-barWidthOverride' => govcms_ckan_get_config_value($config, 'bar_width_override', 'auto'),
       'data-rotated' => govcms_ckan_get_config_value($config, 'rotated'),
       'data-stacked' => (govcms_ckan_get_config_value($config, 'stacked') == 1 ? 'true' : 'false'),
       'data-labels' => (govcms_ckan_get_config_value($config, 'show_labels') == 1 ? 'true' : 'false'),
@@ -159,15 +160,28 @@ function govcms_ckan_display_bar_chart_configure($plugin, $form, &$form_state, $
 
   $config_form['bar_width'] = array(
     '#type' => 'select',
-    '#title' => t('Bar width'),
+    '#title' => t('Bar Ratio'),
     '#default_value' => govcms_ckan_get_config_value($config, 'bar_width', '0.5'),
-    '#description' => t('Override the default width of the bars.'),
+    '#description' => t('Override the default width ratio of the bars.'),
     '#options' => array(
       '0.2' => t('Extra thin'),
       '0.3' => t('Thin'),
       '0.5' => t('Standard'),
       '0.75' => t('Thick'),
       '0.9' => t('Extra thick'),
+      'manual' => t('Manually define width'),
+    ),
+  );
+
+  $config_form['bar_width_override'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Bar width'),
+    '#default_value' => govcms_ckan_get_config_value($config, 'bar_width_override', 6),
+    '#description' => t('Manually set the width of the bars in the chart. Useful if setting X axis values and bar width is incorrect. Numeric whole numbers only or "auto" to use default.'),
+    '#states' => array(
+      'visible' => array(
+        'select#edit-ckan-visualisation-und-0-config-visualisation-config-bar-width' => array('value' => 'manual'),
+      ),
     ),
   );
 


### PR DESCRIPTION
Hey @srowlands 

ENV-435 (sort of fix)

Can now manually define the bar width, rather than using a ratio, this gives us a pretty perfect looking graph with manual x values set... and someone might find it useful for other uses too.
