### PR TITLE
Increased maxlength on text input for updating dataset

### DIFF
--- a/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
+++ b/modules/govcms_ckan_media/includes/govcms_ckan_media.field_config.inc
@@ -185,6 +185,7 @@ function govcms_ckan_media_field_widget_form(&$form, &$form_state, $field, $inst
       '#title' => t('New CKAN dataset resource URL'),
       '#description' => t('<strong>Warning:</strong> Changing the dataset url may have adverse effects, especially if the dataset has a different structure.'),
       '#default_value' => $dataset_url,
+      '#maxlength' => 2083,
     );
 
     // Refresh the keys with the new dataset URL.


### PR DESCRIPTION
So it matches media_internet field maxlength (for really, really long urls)

Hey @gollyg & @srowlands 

This was just a tiny bit of QA feedback on ENV-590 