### PR TITLE
Views integration for CKAN

### DIFF
--- a/modules/govcms_ckan_views/govcms_ckan_views.info
+++ b/modules/govcms_ckan_views/govcms_ckan_views.info
@@ -1,0 +1,15 @@
+name = CKAN Wizard
+description = Views integration for CKAN datasets
+package = govCMS
+core = 7.x
+
+; Ctools plugin classes.
+files[] = plugins/views_wizard/ckan_dataset_views_wizard.class.php
+
+; Views automatically includes if files are in views subdir.
+files[] = views/views_handler_field_ckan_entity.inc
+files[] = views/views_plugin_style_ckan_visualisation.inc
+files[] = views/views_plugin_query_ckan_datastore.inc
+
+; Views handlers to expose some of the CKAN fields for the resources.
+files[] = views/views_handler_filter_ckan.inc

--- a/modules/govcms_ckan_views/govcms_ckan_views.module
+++ b/modules/govcms_ckan_views/govcms_ckan_views.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function govcms_ckan_views_ctools_plugin_directory($module, $plugin) {
+  if ($module == 'views_ui') {
+    return 'plugins/views_wizard';
+  }
+}
+
+/**
+ * Implements hook_views_api().
+ */
+function govcms_ckan_views_views_api() {
+  return [
+    'api' => 3,
+    'path' => drupal_get_path('module', 'govcms_ckan_views'),
+  ];
+}

--- a/modules/govcms_ckan_views/govcms_ckan_views.views.inc
+++ b/modules/govcms_ckan_views/govcms_ckan_views.views.inc
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Implements hook_views_handlers().
+ */
+function govcms_ckan_views_views_handlers() {
+  return [
+    'info' => [
+      'path' => drupal_get_path('module', 'govcms_ckan_views'),
+    ],
+    'handlers' => [],
+  ];
+}
+
+/**
+ * Implements hook_views_plugins().
+ */
+function govcms_ckan_views_views_plugins() {
+  $base = ['ckan_dataset'];
+
+  return [
+    'module' => 'govcms_ckan_views',
+    'query' => [
+      'ckan_datastore' => [
+        'title' => t('CKAN API Query'),
+        'help' => t('Query handler to make API queries directly to a CKAN datastore'),
+        'handler' => 'views_plugin_query_ckan_datastore',
+      ],
+    ],
+    'style' => [
+      'ckan_visualisation' => [
+        'title' => t('CKAN Visualisation'),
+        'help' => t('Display result data with CKAN visualisation plugins'),
+        'handler' => 'views_plugin_style_ckan_visualisation',
+        'help-topic' => 'style-ckan-visualisation',
+        'uses row plugin' => FALSE,
+        'uses row class' => FALSE,
+        'uses options' => TRUE,
+        'uses fields' => FALSE,
+        'type' => 'remote',
+        'base' => $base,
+      ],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_views_data().
+ */
+function govcms_ckan_views_views_data() {
+  $data = [];
+
+  // Instruct views to use the defined query class for CKAN dataset views.
+  $data['ckan_dataset']['table']['group'] = t('CKAN Datastore');
+  $data['ckan_dataset']['table']['base'] = [
+    'title' => t('CKAN datastore'),
+    'help' => t('Query CKAN datastore API'),
+    'query class' => 'ckan_datastore',
+  ];
+
+  // Add a filter to the view. This field will allow the view creator to specify
+  // which API field the user will be submitting so we don't need to create a
+  // specific filter for each type of field.
+  //
+  // @TODO: Potentially need to create generic "string", "int" filters if the
+  // API supports different operators for each field.
+  $data['ckan_dataset']['ckan_field'] = [
+    'title' => t('CKAN Field'),
+    'help' => t('A field that is present in the datastore'),
+    'filter' => [
+      'handler' => 'views_handler_filter_ckan',
+    ],
+  ];
+
+  return $data;
+}

--- a/modules/govcms_ckan_views/plugins/views_wizard/ckan_dataset.inc
+++ b/modules/govcms_ckan_views/plugins/views_wizard/ckan_dataset.inc
@@ -1,0 +1,11 @@
+<?php
+
+$plugin = [
+  'name' => 'ckan_dataset',
+  'base_table' => 'ckan_dataset', // Base table is used to register fields.
+  'title' => t('CKAN Dataset'),
+  'form_wizard_class' => [
+    'file' => 'ckan_dataset_views_wizard.class.php',
+    'class' => 'CkanDatasetViewsWizard',
+  ],
+];

--- a/modules/govcms_ckan_views/plugins/views_wizard/ckan_dataset_views_wizard.class.php
+++ b/modules/govcms_ckan_views/plugins/views_wizard/ckan_dataset_views_wizard.class.php
@@ -1,0 +1,51 @@
+<?php
+
+
+class CkanDatasetViewsWizard extends ViewsUiBaseViewsWizard {
+
+  /**
+   * Override the build_form.
+   *
+   * Removes pager options from the wizard as these are not relevant.
+   *
+   * @TODO: Look at implementing pagination to this view type.
+   */
+  public function build_form($form, &$form_state) {
+    $form = parent::build_form($form, $form_state);
+
+    unset($form['displays']['page']['items_per_page']);
+    unset($form['displays']['page']['options']['pager']);
+
+    return $form;
+  }
+
+  /**
+   * Override the build_form_style so we can specify which plugins to show.
+   *
+   * Relies on Style plugins being defined with a 'remote' type.
+   *
+   * @see parent::build_form_style
+   * @see views_fetch_plugin_names
+   * @see govcms_ckan_views_plugins
+   */
+  protected function build_form_style(&$form, &$form_state, $type) {
+    // Potentially reconfigure the style plugins as 'ckan' as opposed to using
+    // 'remote'.
+    $style_options = views_fetch_plugin_names('style', 'remote', array($this->base_table));
+
+    $style_form =& $form['displays'][$type]['options']['style'];
+    $style_form['style_plugin']['#options'] = $style_options;
+  }
+
+  protected function default_display_options($form, $form_state) {
+    $display_options = parent::default_display_options($form, $form_state);
+
+    $display_options['style_plugin'] = 'ckan_visualisation';
+
+    // Remove the default display option.
+    unset($display_options['fields']);
+
+    return $display_options;
+  }
+
+}

--- a/modules/govcms_ckan_views/views/views_handler_filter_ckan.inc
+++ b/modules/govcms_ckan_views/views/views_handler_filter_ckan.inc
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Class views_handler_filter_ckan.
+ *
+ * Generic filter for CKAN visulisation views. This will allow you to specify
+ * the field that you want to query with.
+ */
+
+class views_handler_filter_ckan extends views_handler_filter_string {
+
+  /**
+   * The field for the CKAN resource that this field uses.
+   *
+   * @var string
+   */
+  var $ckan_field_name = NULL;
+
+  public function init(&$view, &$options) {
+    parent::init($view, $options);
+    $this->ckan_field_name = $this->options['ckan_field_name'];
+  }
+
+  /**
+   * Define an option for the definition.
+   *
+   * Updates the option definiton for the filter to include the field name that
+   * we will allow view creators to specify.
+   *
+   * @return array
+   */
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['ckan_field_name'] = array('default' => '');
+
+    return $options;
+  }
+
+  /**
+   * A list of operators that this filter can support.
+   *
+   * @TODO: Review the API docs to see if we can specify any other operators. A
+   * brief review suggested that unless we use postgres mode we are limited to
+   * contains queries.
+   *
+   * @return array
+   */
+  function operators() {
+    return [
+      'contains' => [
+        'title' => t('Contains'),
+        'short' => t('contains'),
+        'method' => 'add_filter',
+        'values' => 1,
+      ],
+    ];
+  }
+
+  /**
+   * Add the filter to the views query.
+   */
+  function add_filter() {
+    // @TODO: Fields are per resource an initial query to the CKAN endpoint will
+    // reveal all fields that are available under keys. This could be done
+    // when the form is loaded and then stored with this filter.
+    $this->query->add_filter($this->ckan_field_name, $this->value);
+  }
+
+  /**
+   * Add the CKAN field name field to the
+   *
+   * @see parent::value_form
+   */
+  public function value_form(&$form, &$form_state) {
+    parent::value_form($form, $form_state);
+
+    $form['ckan_field_name'] = [
+      '#type' => 'textfield',
+      '#title' => t('CKAN Field Name'),
+      '#description' => t('The name of the field as it appears in the CKAN dataset.'),
+      '#default_value' => $this->ckan_field_name,
+    ];
+
+    if (!empty($this->view->filter['ckan_resource_id'])) {
+      $form['ckan_field_name']['#type'] = 'select';
+      $form['ckan_field_name']['#options'] = $this->get_field_options();
+    }
+  }
+
+  /**
+   * Alter the exposed form when this filter is used.
+   *
+   * @see parent::exposed_form
+   */
+  public function exposed_form(&$form, &$form_state) {
+    parent::exposed_form($form, $form_state);
+    // Because we require the field name as input it will be appended to the
+    // exposed filter form as well. Unsetting this here removes it, when the
+    // field is added to the query Views will know which field is to be used.
+    unset($form['ckan_field_name']);
+  }
+
+  /**
+   * Make a request to the configured datasets and retrieve a list
+   *
+   * @return array
+   *   As expected for
+   */
+  public function get_field_options() {
+    // @TODO: Remote request if the 'ckan_resource_id' filter has been applied
+    // to the view.
+    return [];
+  }
+
+}

--- a/modules/govcms_ckan_views/views/views_plugin_query_ckan_datastore.inc
+++ b/modules/govcms_ckan_views/views/views_plugin_query_ckan_datastore.inc
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class views_plugin_query_ckan_datastore
+ *
+ * Views query plugin that encapsulates calls to the API defined
+ * in the CKAN module.
+ */
+
+class views_plugin_query_ckan_datastore extends views_plugin_query {
+
+  /**
+   * A list of filters to apply to the API request.
+   * @var array
+   */
+  protected $filters = [];
+
+//  protected $resources = ['23be1fc4-b6ef-4013-9102-c014c9d48711'];
+
+  /**
+   * A list of resource IDs we will be querying.
+   * @var array
+   */
+  protected $resources = [
+    'eb1e6be4-5b13-4feb-b28e-388bf7c26f93',
+    'ce8bf129-9525-4353-a747-d89d8d4b5cc6',
+  ];
+
+  /**
+   * Prepare the filters to be sent to the endpoint.
+   *
+   * @TODO this may need to change if the API supports different operators.
+   */
+  private function prepare_filters() {
+    return json_encode($this->filters);
+  }
+
+  /**
+   * Add a filter to the query.
+   *
+   * @param string $field
+   *   A field to query on.
+   * @param string $value
+   *   The value to query for.
+   *
+   * @TODO: Investigate CKAN API as it may support operators to be parsed in
+   * via the JSON string.
+   */
+  public function add_filter($field, $value) {
+    $this->filters[$field] = $value;
+  }
+
+  /**
+   * Resource ID/s should be set via the Resource ID filter.
+   *
+   * @param $id
+   *   A CKAN resource ID.
+   */
+  public function add_resource($id) {
+    $this->resources[] = $id;
+  }
+
+  /**
+   * Send an API request to the views defined CKAN resource.
+   *
+   * A view can have multiple resources defined. This will allow the user
+   * to query multiple datasets and merge the results into one graph.
+   *
+   * @TODO: Use the request class defined in CKAN module.
+   * @TODO: Add filter to add resource IDs to the view as so not hard coding.
+   */
+  public function execute(&$view) {
+    $view->result = [];
+
+    foreach ($this->resources as $id) {
+      $url = url('http://data.gov.au/api/3/action/datastore_search', [
+        'query' => [
+          'id' => $id,
+          'q' => $this->prepare_filters(),
+          'limit' => 100,
+        ],
+      ]);
+
+      $response = drupal_http_request($url);
+      $data = json_decode($response->data);
+
+      $view->result[$id] = $data->result->records;
+    }
+
+  }
+
+}

--- a/modules/govcms_ckan_views/views/views_plugin_style_ckan_visualisation.inc
+++ b/modules/govcms_ckan_views/views/views_plugin_style_ckan_visualisation.inc
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class views_plugin_style_ckan_visualisation
+ *
+ * Style plugin for views to integrate with CKAN visualisation plugins.
+ */
+
+class views_plugin_style_ckan_visualisation extends views_plugin_style {
+
+  /**
+   * @TODO: Update this so that the options form allow the user to choose which
+   * visualisation to use when rendering the view.
+   */
+
+  /**
+   * Ensure that uses_fields() always returns FALSE.
+   *
+   * This affects the Views UI by not allowing users to change how the display
+   * behaves. All display options should be managed via code
+   */
+  public function uses_fields() {
+    return FALSE;
+  }
+
+  /**
+   * Render the results of a request to the CKAN API.
+   *
+   * This method should be used to handle grouping result sets together a view
+   * should always group the response from the CKAN API via the resource ID.
+   *
+   * eg.
+   *    {RESOURCE_ID} => [ ... ]
+   *    {RESOURCE_ID} => [ ... ]
+   *
+   * @see views_plugin_style::render
+   * @see views_plugin_style::render_grouping_sets
+   *
+   * @TODO: This should be rendered with the CKAN plugin so all JS is applied.
+   */
+  public function render() {
+    $output = '';
+
+    foreach ($this->view->result as $id => $result) {
+      $row = reset($result);
+      $headers = array_keys((array) $row);
+
+      // @TODO: Instead of using theme functions use the render function defined
+      // in the CKAN visualisation plugin.
+      $output .= theme('table', [
+        'header' => $headers,
+        'rows' => json_decode(json_encode($result), TRUE),
+      ]);
+    }
+
+    return $output;
+  }
+}


### PR DESCRIPTION
Begin integration with views to pull back CKAN data. This will allow arbitrary queries to the CKAN API across multiple resources and will expose fields to the user such that they can query the data provided.

- Adds new views type: CKAN dataset
- Adds new view query handler: CKAN
- Adds new view display: CKAN visualisation
- Adds new view filter field: CKAN Field